### PR TITLE
Encode `&` character in generated RSS

### DIFF
--- a/scripts/lib/rss.js
+++ b/scripts/lib/rss.js
@@ -62,7 +62,7 @@ function Rss()
 
 String.prototype.to_rss = function()
 {
-  return this.replace(/\</g,"&lt;").replace(/\>/g,"&gt;").replace(/\"/g,"&quot;").replace(/\'/g,"&apos;")
+  return this.replace(/&(?!\w*;)/g,"&amp;").replace(/\</g,"&lt;").replace(/\>/g,"&gt;").replace(/\"/g,"&quot;").replace(/\'/g,"&apos;");
 }
 
 String.prototype.to_entities = function()


### PR DESCRIPTION
I added support for encoding the `&` character to the function generating the RSS feed, as you suggested in #4. 

The regex will replace any single `&` that are not followed by other characters and a `;`, e.g. `&lt;`.