### PR TITLE
Improve mobile layout

### DIFF
--- a/links/main.css
+++ b/links/main.css
@@ -87,7 +87,13 @@ ul.nobull li {list-style-type: none}
 /* Mobile */
 
 @media screen and (max-width: 1100px) {
-	nav { width: 100%; float:none; vertical-align: top; }
-	nav ul { float: left; margin-right:30px; width: calc(33% - 90px) }
-	nav h2 { display: none }
+	nav { width: 100%; }
+  nav::after { content: ""; display: block; clear: both; }
+	nav h2 { margin: 0 0 15px 0; }
+	nav > section { float: left; margin: 0 30px 30px 0; }
+  nav > section { width: calc(33% - 30px); }
+}
+
+@media screen and (max-width: 600px) {
+  nav > section { width: 33%; }
 }

--- a/links/main.css
+++ b/links/main.css
@@ -9,9 +9,9 @@ header a img {}
 
 nav { padding: 45px; float: left; }
 nav details summary { margin-bottom: 30px }
-nav section { line-height: 22px; margin-bottom: 40px;}
-nav section h2 { margin: 20px 0 20px 0; }
-nav section ul { margin: 0px; padding: 0px; }
+nav .site-nav section { line-height: 22px; margin-bottom: 40px;}
+nav .site-nav section h2 { margin: 20px 0 20px 0; }
+nav .site-nav section ul { margin: 0px; padding: 0px; }
 
 main { padding: 45px; float:left; max-width:700px; }
 main > img { width:100%; max-width: 700px }
@@ -88,23 +88,23 @@ ul.nobull li {list-style-type: none}
 
 @media (max-width: 1100px) {
   nav { width: 100%; }
-	nav > section { float: left; margin: 0 10px 10px 0; }
+	nav .site-nav section { float: left; margin: 0 10px 10px 0; }
 }
 @media (max-width: 1100px) and (min-width: 651px) {
-  nav > section { width: calc(25% - 10px); }
-  nav > section:nth-child(4n + 1) { clear: left; }
+  nav .site-nav section { width: calc(25% - 10px); }
+  nav .site-nav section:nth-child(4n + 1) { clear: left; }
 }
 
 @media (max-width: 650px) and (min-width: 501px) {
-  nav > section { width: calc(33% - 10px); }
-  nav > section:nth-child(3n + 1) { clear: left; }
+  nav .site-nav section { width: calc(33% - 10px); }
+  nav .site-nav section:nth-child(3n + 1) { clear: left; }
 }
 
 @media (max-width: 500px) and (min-width: 351px) {
-  nav > section { width: calc(50% - 10px); }
-  nav > section:nth-child(2n + 1) { clear: left; }
+  nav .site-nav section { width: calc(50% - 10px); }
+  nav .site-nav section:nth-child(2n + 1) { clear: left; }
 }
 
 @media (max-width: 350px) {
-  nav > section { width: 100%; }
+  nav .site-nav section { width: 100%; }
 }

--- a/links/main.css
+++ b/links/main.css
@@ -87,12 +87,11 @@ ul.nobull li {list-style-type: none}
 /* Mobile */
 
 @media (max-width: 1100px) {
-	nav { width: 100%; }
-	nav > section { float: left; }
-  nav > section { margin: 0 10px 10px 0; }
-  nav > section { width: calc(25% - 10px); }
+  nav { width: 100%; }
+	nav > section { float: left; margin: 0 10px 10px 0; }
 }
 @media (max-width: 1100px) and (min-width: 651px) {
+  nav > section { width: calc(25% - 10px); }
   nav > section:nth-child(4n + 1) { clear: left; }
 }
 

--- a/links/main.css
+++ b/links/main.css
@@ -86,14 +86,26 @@ ul.nobull li {list-style-type: none}
 
 /* Mobile */
 
-@media screen and (max-width: 1100px) {
+@media (max-width: 1100px) {
 	nav { width: 100%; }
-  nav::after { content: ""; display: block; clear: both; }
-	nav h2 { margin: 0 0 15px 0; }
-	nav > section { float: left; margin: 0 30px 30px 0; }
-  nav > section { width: calc(33% - 30px); }
+	nav > section { float: left; }
+  nav > section { margin: 0 10px 10px 0; }
+  nav > section { width: calc(25% - 10px); }
+}
+@media (max-width: 1100px) and (min-width: 651px) {
+  nav > section:nth-child(4n + 1) { clear: left; }
 }
 
-@media screen and (max-width: 600px) {
-  nav > section { width: 33%; }
+@media (max-width: 650px) and (min-width: 501px) {
+  nav > section { width: calc(33% - 10px); }
+  nav > section:nth-child(3n + 1) { clear: left; }
+}
+
+@media (max-width: 500px) and (min-width: 351px) {
+  nav > section { width: calc(50% - 10px); }
+  nav > section:nth-child(2n + 1) { clear: left; }
+}
+
+@media (max-width: 350px) {
+  nav > section { width: 100%; }
 }

--- a/links/main.css
+++ b/links/main.css
@@ -7,11 +7,11 @@ body { background:#fff; color:#000; overflow-x: hidden; font-family: sans-serif;
 header { padding: 45px; border-bottom: 1px solid #222; }
 header a img {}
 
-main { padding: 45px; float:left; max-width:700px; }
 nav { padding:45px; float:left; }
 nav details summary { margin-bottom: 30px }
 nav ul { margin-left:0px; padding-left:0px; line-height: 22px}
 
+main { padding: 45px; float:left; max-width:700px; }
 main > img { width:100%; max-width: 700px }
 main > * { max-width: 600px; margin-bottom: 30px }
 main > h1 { font-size:45px; text-transform: capitalize; display: none}
@@ -62,7 +62,7 @@ footer hr { margin-bottom: 15px }
 
 a { color: black }
 
-a:visited { color:#aaa; } 
+a:visited { color:#aaa; }
 
 ul { margin:0px 0px 30px 0px; }
 

--- a/links/main.css
+++ b/links/main.css
@@ -7,9 +7,11 @@ body { background:#fff; color:#000; overflow-x: hidden; font-family: sans-serif;
 header { padding: 45px; border-bottom: 1px solid #222; }
 header a img {}
 
-nav { padding:45px; float:left; }
+nav { padding: 45px; float: left; }
 nav details summary { margin-bottom: 30px }
-nav ul { margin-left:0px; padding-left:0px; line-height: 22px}
+nav section { line-height: 22px; margin-bottom: 40px;}
+nav section h2 { margin: 20px 0 20px 0; }
+nav section ul { margin: 0px; padding: 0px; }
 
 main { padding: 45px; float:left; max-width:700px; }
 main > img { width:100%; max-width: 700px }

--- a/src/inc/meta.nav.htm
+++ b/src/inc/meta.nav.htm
@@ -1,76 +1,90 @@
 <details open>
     <summary>Menu</summary>
-    <ul class='nobull capital'>
-        <li><a href='about_us.html'>about us</a></li>
-        <li><a href='mission.html'>mission</a></li>
-        <li><a href='philosophy.html'>philosophy</a></li>
-        <li><a href='pino.html'>pino</a></li>
-        <li><a href='videos.html'>videos</a></li>
-        <li><a href='support.html'>support</a></li>
-        <li><a href='store.html'>store</a></li>
-        <li><a href='press.html'>press</a></li>
-    </ul>
-    <h2><a id='knowledge'>knowledge</a></h2>
-    <ul class='nobull capital'>
-        <li><a href='off_the_grid.html'>off the grid</a></li>
-        <li><a href='liveaboard.html'>liveaboard</a></li>
-        <li><a href='sailing.html'>sailing</a></li>
-        <li><a href='cooking.html'>cooking</a></li>
-        <li><a href='costs.html'>costs</a></li>
-        <li><a href='weather.html'>weather</a></li>
-        <li><a href='resources.html'>resources</a></li>
-        <li><a href='raspberry_pi.html'>raspberry pi</a></li>
-        <li><a href='6502_assembly.html'>6502 assembly</a></li>
-    </ul>
-    <h2><a id='blog'>blog</a></h2>
-    <ul class='nobull capital'>
-        <li><a href='log.html'>log</a></li>
-        <li><a href='working_offgrid_efficiently.html'>working offgrid efficiently</a></li>
-        <li><a href='tools_ecosystem.html'>tools ecosystem</a></li>
-        <li><a href='buying_a_sailboat.html'>buying a sailboat</a></li>
-    </ul>
-    <h2><a id='tools'>tools</a></h2>
-    <ul class='nobull capital'>
-        <li><a href='orca.html'>orca</a></li>
-        <li><a href='dotgrid.html'>dotgrid</a></li>
-        <li><a href='ronin.html'>ronin</a></li>
-        <li><a href='left.html'>left</a></li>
-        <li><a href='nasu.html'>nasu</a></li>
-    </ul>
-    <h2><a id='games'>games</a></h2>
-    <ul class='nobull capital'>
-        <li><a href='markl.html'>markl</a></li>
-        <li><a href='oquonie.html'>oquonie</a></li>
-        <li><a href='donsol.html'>donsol</a></li>
-        <li><a href='paradise.html'>paradise</a></li>
-        <li><a href='hiversaires.html'>hiversaires</a></li>
-        <li><a href='verreciel.html'>verreciel</a></li>
-    </ul>
-    <h2><a id='books'>books</a></h2>
-    <ul class='nobull capital'>
-        <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-        <li><a href='wiktopher.html'>wiktopher</a></li>
-        <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-        <li><a href='library.html'>library</a></li>
-    </ul>
-
-    <h2><a id='travel'>travel</a></h2>
-    <ul class='nobull capital'>
-        <li><a href='us_west_coast.html'>US West Coast</a></li>
-        <li><a href='mexico.html'>mexico</a></li>
-        <li><a href='french_polynesia.html'>french polynesia</a></li>
-        <li><a href='cook_islands.html'>cook islands</a></li>
-        <li><a href='niue.html'>niue</a></li>
-        <li><a href='tonga.html'>tonga</a></li>
-        <li><a href='new_zealand.html'>new zealand</a></li>
-        <li><a href='fiji.html'>fiji</a></li>
-        <li><a href='marshall_islands.html'>marshall islands</a></li>
-        <li><a href='japan.html'>japan</a></li>
-        <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-    </ul>
-
-    <h2><a id='meta'>Meta</a></h2>
-    <ul class='nobull capital'>
-        <li>{index}</li>
-    </ul>
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='raspberry_pi.html'>raspberry pi</a></li>
+            <li><a href='6502_assembly.html'>6502 assembly</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='working_offgrid_efficiently.html'>working offgrid efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>tools ecosystem</a></li>
+            <li><a href='buying_a_sailboat.html'>buying a sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='us_west_coast.html'>US West Coast</a></li>
+            <li><a href='mexico.html'>mexico</a></li>
+            <li><a href='french_polynesia.html'>french polynesia</a></li>
+            <li><a href='cook_islands.html'>cook islands</a></li>
+            <li><a href='niue.html'>niue</a></li>
+            <li><a href='tonga.html'>tonga</a></li>
+            <li><a href='new_zealand.html'>new zealand</a></li>
+            <li><a href='fiji.html'>fiji</a></li>
+            <li><a href='marshall_islands.html'>marshall islands</a></li>
+            <li><a href='japan.html'>japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li>{index}</li>
+        </ul>
+    </section>
 </details>

--- a/src/inc/meta.nav.htm
+++ b/src/inc/meta.nav.htm
@@ -1,90 +1,92 @@
 <details open>
     <summary>Menu</summary>
-    <section>
-        <ul class='nobull capital'>
-            <li><a href='about_us.html'>about us</a></li>
-            <li><a href='mission.html'>mission</a></li>
-            <li><a href='philosophy.html'>philosophy</a></li>
-            <li><a href='pino.html'>pino</a></li>
-            <li><a href='videos.html'>videos</a></li>
-            <li><a href='support.html'>support</a></li>
-            <li><a href='store.html'>store</a></li>
-            <li><a href='press.html'>press</a></li>
-        </ul>
-    </section>
-    <section>
-        <h2><a id='knowledge'>knowledge</a></h2>
-        <ul class='nobull capital'>
-            <li><a href='off_the_grid.html'>off the grid</a></li>
-            <li><a href='liveaboard.html'>liveaboard</a></li>
-            <li><a href='sailing.html'>sailing</a></li>
-            <li><a href='cooking.html'>cooking</a></li>
-            <li><a href='costs.html'>costs</a></li>
-            <li><a href='weather.html'>weather</a></li>
-            <li><a href='resources.html'>resources</a></li>
-            <li><a href='raspberry_pi.html'>raspberry pi</a></li>
-            <li><a href='6502_assembly.html'>6502 assembly</a></li>
-        </ul>
-    </section>
-    <section>
-        <h2><a id='blog'>blog</a></h2>
-        <ul class='nobull capital'>
-            <li><a href='log.html'>log</a></li>
-            <li><a href='working_offgrid_efficiently.html'>working offgrid efficiently</a></li>
-            <li><a href='tools_ecosystem.html'>tools ecosystem</a></li>
-            <li><a href='buying_a_sailboat.html'>buying a sailboat</a></li>
-        </ul>
-    </section>
-    <section>
-        <h2><a id='tools'>tools</a></h2>
-        <ul class='nobull capital'>
-            <li><a href='orca.html'>orca</a></li>
-            <li><a href='dotgrid.html'>dotgrid</a></li>
-            <li><a href='ronin.html'>ronin</a></li>
-            <li><a href='left.html'>left</a></li>
-            <li><a href='nasu.html'>nasu</a></li>
-        </ul>
-    </section>
-    <section>
-        <h2><a id='games'>games</a></h2>
-        <ul class='nobull capital'>
-            <li><a href='markl.html'>markl</a></li>
-            <li><a href='oquonie.html'>oquonie</a></li>
-            <li><a href='donsol.html'>donsol</a></li>
-            <li><a href='paradise.html'>paradise</a></li>
-            <li><a href='hiversaires.html'>hiversaires</a></li>
-            <li><a href='verreciel.html'>verreciel</a></li>
-        </ul>
-    </section>
-    <section>
-        <h2><a id='books'>books</a></h2>
-        <ul class='nobull capital'>
-            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-            <li><a href='wiktopher.html'>wiktopher</a></li>
-            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-            <li><a href='library.html'>library</a></li>
-        </ul>
-    </section>
-    <section>
-        <h2><a id='travel'>travel</a></h2>
-        <ul class='nobull capital'>
-            <li><a href='us_west_coast.html'>US West Coast</a></li>
-            <li><a href='mexico.html'>mexico</a></li>
-            <li><a href='french_polynesia.html'>french polynesia</a></li>
-            <li><a href='cook_islands.html'>cook islands</a></li>
-            <li><a href='niue.html'>niue</a></li>
-            <li><a href='tonga.html'>tonga</a></li>
-            <li><a href='new_zealand.html'>new zealand</a></li>
-            <li><a href='fiji.html'>fiji</a></li>
-            <li><a href='marshall_islands.html'>marshall islands</a></li>
-            <li><a href='japan.html'>japan</a></li>
-            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-        </ul>
-    </section>
-    <section>
-        <h2><a id='meta'>Meta</a></h2>
-        <ul class='nobull capital'>
-            <li>{index}</li>
-        </ul>
+    <section class="site-nav">
+        <section>
+            <ul class='nobull capital'>
+                <li><a href='about_us.html'>about us</a></li>
+                <li><a href='mission.html'>mission</a></li>
+                <li><a href='philosophy.html'>philosophy</a></li>
+                <li><a href='pino.html'>pino</a></li>
+                <li><a href='videos.html'>videos</a></li>
+                <li><a href='support.html'>support</a></li>
+                <li><a href='store.html'>store</a></li>
+                <li><a href='press.html'>press</a></li>
+            </ul>
+        </section>
+        <section>
+            <h2><a id='knowledge'>knowledge</a></h2>
+            <ul class='nobull capital'>
+                <li><a href='off_the_grid.html'>off the grid</a></li>
+                <li><a href='liveaboard.html'>liveaboard</a></li>
+                <li><a href='sailing.html'>sailing</a></li>
+                <li><a href='cooking.html'>cooking</a></li>
+                <li><a href='costs.html'>costs</a></li>
+                <li><a href='weather.html'>weather</a></li>
+                <li><a href='resources.html'>resources</a></li>
+                <li><a href='raspberry_pi.html'>raspberry pi</a></li>
+                <li><a href='6502_assembly.html'>6502 assembly</a></li>
+            </ul>
+        </section>
+        <section>
+            <h2><a id='blog'>blog</a></h2>
+            <ul class='nobull capital'>
+                <li><a href='log.html'>log</a></li>
+                <li><a href='working_offgrid_efficiently.html'>working offgrid efficiently</a></li>
+                <li><a href='tools_ecosystem.html'>tools ecosystem</a></li>
+                <li><a href='buying_a_sailboat.html'>buying a sailboat</a></li>
+            </ul>
+        </section>
+        <section>
+            <h2><a id='tools'>tools</a></h2>
+            <ul class='nobull capital'>
+                <li><a href='orca.html'>orca</a></li>
+                <li><a href='dotgrid.html'>dotgrid</a></li>
+                <li><a href='ronin.html'>ronin</a></li>
+                <li><a href='left.html'>left</a></li>
+                <li><a href='nasu.html'>nasu</a></li>
+            </ul>
+        </section>
+        <section>
+            <h2><a id='games'>games</a></h2>
+            <ul class='nobull capital'>
+                <li><a href='markl.html'>markl</a></li>
+                <li><a href='oquonie.html'>oquonie</a></li>
+                <li><a href='donsol.html'>donsol</a></li>
+                <li><a href='paradise.html'>paradise</a></li>
+                <li><a href='hiversaires.html'>hiversaires</a></li>
+                <li><a href='verreciel.html'>verreciel</a></li>
+            </ul>
+        </section>
+        <section>
+            <h2><a id='books'>books</a></h2>
+            <ul class='nobull capital'>
+                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+                <li><a href='wiktopher.html'>wiktopher</a></li>
+                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+                <li><a href='library.html'>library</a></li>
+            </ul>
+        </section>
+        <section>
+            <h2><a id='travel'>travel</a></h2>
+            <ul class='nobull capital'>
+                <li><a href='us_west_coast.html'>US West Coast</a></li>
+                <li><a href='mexico.html'>mexico</a></li>
+                <li><a href='french_polynesia.html'>french polynesia</a></li>
+                <li><a href='cook_islands.html'>cook islands</a></li>
+                <li><a href='niue.html'>niue</a></li>
+                <li><a href='tonga.html'>tonga</a></li>
+                <li><a href='new_zealand.html'>new zealand</a></li>
+                <li><a href='fiji.html'>fiji</a></li>
+                <li><a href='marshall_islands.html'>marshall islands</a></li>
+                <li><a href='japan.html'>japan</a></li>
+                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+            </ul>
+        </section>
+        <section>
+            <h2><a id='meta'>Meta</a></h2>
+            <ul class='nobull capital'>
+                <li>{index}</li>
+            </ul>
+        </section>
     </section>
 </details>


### PR DESCRIPTION
This PR makes the following changes in an effort to improve the legibility of the navigation links in narrow screen sizes:

- The `<h2>` and `<ul>` pairs in `src/inc/meta.nav.htm` are now enclosed in `<section>`s in order to more easily style them as a single unit.
- Added more media query screen width divisions combined with the [`:nth-child()` pseudo-class](https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-child) in order to simulate a flexbox wrapping layout and to prevent floated `<sections>` from getting caught on each other in visually unpleasant ways.

I tested it in the latest versions of Chrome, Firefox, NetSurf, and Internet Explorer and they all seem to render these changes alright from what I can tell. I'm happy to make changes if requested.

**Note:** This PR doesn't include the changes produced by running the `src/build.sh` script because of how many changed files it produced that cluttered up the diff.