### PR TITLE
fix: remove duplicate book from library.htm

### DIFF
--- a/src/inc/library.htm
+++ b/src/inc/library.htm
@@ -130,7 +130,6 @@
     <li>Blumroch L'admirable</a>, Louis Pauwels</li>
     <li>Cyberiad, Stanislaw Lem</li>
     <li>Ishmael, Daniel Quinn</li>
-    <li>The long way, Bernard Moitessier</li>
     <li>Duck, death and the tulip</a>, Wolf Erlbruch</li>
     <li>How not to die, Michael Greger</li>
     <li>A Sand County Almanac, Aldo Leopold</li>


### PR DESCRIPTION
It looks to me like you have a duplicate book in the permanent collection.

If this is intended, sorry for the noise :)