### PR TITLE
Use semantic HTML for keyboard shortcuts

### DIFF
--- a/links/main.css
+++ b/links/main.css
@@ -63,6 +63,7 @@ main > table.col b { font-weight: bold }
 
 main img.detail { max-width: 64px; float: left;border: 1px solid #777;padding: 20px;margin: 0px 20px 20px 0px;border-radius: 3px; }
 main .shortcut { background: #fff; display: inline-block; padding: 2px 5px; margin: 0px; color: black; font-size: 12px; line-height: 16px; border-radius: 2px; }
+main .shortcut-list dt, main .shortcut-list dd { display: inline; line-height: 25px; margin-left: 0; margin-right: 10px; }
 
 main > table.logbook tr td { padding-bottom: 15px;padding-top: 15px; }
 main > table img { max-width: 100%; display: block; margin:20px 0;}

--- a/src/inc/left.htm
+++ b/src/inc/left.htm
@@ -48,27 +48,27 @@
 
 <h3><a id='controls'>Controls</a></h3>
 
-<ul class='col2'>
-  <li><code class='shortcut'>alt+mouse2</code> find from top</li>
-  <li><code class='shortcut'>ctrl+mouse2</code> cut and find</li>
-  <li><code class='shortcut'>backspace/delete</code> erase</li>
-  <li><code class='shortcut'>escape</code> deselect</li>
-  <li><code class='shortcut'>arrow</code>move</li>
-  <li><code class='shortcut'>ctrl+up</code> next label</li>
-  <li><code class='shortcut'>ctrl+down</code> prev label</li>
-  <li><code class='shortcut'>ctrl+left</code> end of line</li>
-  <li><code class='shortcut'>ctrl+right</code> start of line</li>
-  <li><code class='shortcut'>alt+left</code> next word</li>
-  <li><code class='shortcut'>alt+right</code> prev word</li>
-  <li><code class='shortcut'>shift+arrow</code> scale selection</li>
-  <li><code class='shortcut'>ctrl+a</code> select all</li>
-</ul>
+<dl class='col2 shortcut-list' aria-labelledby='controls'>
+  <div><dt><kbd class='shortcut'><kbd>alt</kbd> + <kbd>mouse2</kbd></kbd></dt><dd>find from top</dd></div>
+  <div><dt><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>mouse2</kbd></kbd></dt><dd>cut and find</dd></div>
+  <div><dt><kbd class='shortcut'><kbd>backspace/delete</kbd></kbd></dt><dd>erase</dd></div>
+  <div><dt><kbd class='shortcut'><kbd>escape</kbd></kbd></dt><dd>deselect</dd></div>
+  <div><dt><kbd class='shortcut'><kbd>arrow</kbd></kbd></dt><dd>move</dd></div>
+  <div><dt><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>up</kbd></kbd></dt><dd>next label</dd></div>
+  <div><dt><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>down</kbd></kbd></dt><dd>prev label</dd></div>
+  <div><dt><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>left</kbd></kbd></dt><dd>end of line</dd></div>
+  <div><dt><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>right</kbd></kbd></dt><dd>start of line</dd></div>
+  <div><dt><kbd class='shortcut'><kbd>alt</kbd> + <kbd>left</kbd></kbd></dt><dd>next word</dd></div>
+  <div><dt><kbd class='shortcut'><kbd>alt</kbd> + <kbd>right</kbd></kbd></dt><dd>prev word</dd></div>
+  <div><dt><kbd class='shortcut'><kbd>shift</kbd> + <kbd>arrow</kbd></kbd></dt><dd>scale selection</dd></div>
+  <div><dt><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>a</kbd></kbd></dt><dd>select all</dd></div>
+</dl>
 
 <h2 id='tutorial'>Tutorial</h2>
 
 <h3 id='rename'>Renaming a file</h3>
 
-<p>To rename a file, press <b>ctrl+r</b> and save it with a <b>.txt</b> extension.</p>
+<p>To rename a file, press <kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>r</kbd></kbd> and save it with a <b>.txt</b> extension.</p>
 
 <hr />
 
@@ -78,45 +78,45 @@
 
 <code>cat > .snarf</code>
 
-<p>Paste your text, press enter and exit with <b>ctrl+c</b>. Then, select the text, copy it and paste it in your Left file.</p>
+<p>Paste your text, press enter and exit with <kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>c</kbd></kbd>. Then, select the text, copy it and paste it in your Left file.</p>
 
 <hr />
 
 <h3><a id='leap'>Leap</a></h3>
 
-<p>The <b>alt key</b> is used as a <a href='https://www.youtube.com/watch?v=o_TlE_U_X3c' target='_blank'>LEAP key</a>(YouTube) to navigate the body of the text.</p>
+<p>The <kbd class='shortcut'>alt</kbd> key is used as a <a href='https://www.youtube.com/watch?v=o_TlE_U_X3c' target='_blank'>LEAP key</a>(YouTube) to navigate the body of the text.</p>
 
 <hr />
 
 
 <h3><a id='word'>Finding a word</a></h3>
 
-<p>Finding a word is done by holding down the <b>alt key</b>, and typing characters, and releasing <b>alt</b> to jump. Alternatively, you can select a word with <b>mouse2</b>, and jump to the next instance with <b>mouse3</b>, you can change the direction of the jump with <b>alt+tab</b>.</p>
+<p>Finding a word is done by holding down the <kbd class='shortcut'>alt</kbd> key, and typing characters, and releasing <kbd class='shortcut'>alt</kbd> to jump. Alternatively, you can select a word with <kbd class='shortcut'>mouse2</kbd>, and jump to the next instance with <kbd class='shortcut'>mouse3</kbd>, you can change the direction of the jump with <kbd class='shortcut'><kbd>alt</kbd> + <kbd>tab</kbd></kbd>.</p>
 
-<ul>
-  <li><code class='shortcut'>mouse1</code> select character</li>
-  <li><code class='shortcut'>mouse2</code> select word</li>
-  <li><code class='shortcut'>mouse3</code> find</li>
-</ul>
+<dl class='shortcut-list'>
+  <div><dt><kbd class='shortcut'>mouse1</kbd></dt><dd>select character</dd></div>
+  <div><dt><kbd class='shortcut'>mouse2</kbd></dt><dd>select word</dd></div>
+  <div><dt><kbd class='shortcut'>mouse3</kbd></dt><dd>find</dd></div>
+</dl>
 
 <hr />
 
 <h3><a id='directory'>Directory</a></h3>
 
-<p>A listing of the files in the active directory can be seen by the sequence <b>ctrl+r del</b>, a file from that listing can be opened by the sequence <b>mouse2 ctrl+g</b>.</p>
+<p>A listing of the files in the active directory can be seen by the sequence <kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>r</kbd></kbd> <kbd class='shortcut'>del</kbd>, a file from that listing can be opened by the sequence <kbd class='shortcut'>mouse2</kbd> <kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>g</kbd></kbd>.</p>
 
-<ul class='col2'>
-  <li><code class='shortcut'>ctrl+n</code> new</li>
-  <li><code class='shortcut'>ctrl+s</code> save</li>
-  <li><code class='shortcut'>ctrl+o</code> open</li>
-  <li><code class='shortcut'>ctrl+g</code> open selection</li>
-  <li><code class='shortcut'>ctrl+r</code> rename</li>
-  <li><code class='shortcut'>ctrl+c</code> copy</li>
-  <li><code class='shortcut'>ctrl+v</code> paste</li>
-  <li><code class='shortcut'>ctrl+x</code> cut</li>
-  <li><code class='shortcut'>ctrl+h</code> toggle syntax</li>
-  <li><code class='shortcut'>ctrl+f</code> toggle font</li>
-</ul>
+<dl class='col2 shortcut-list'>
+  <div><dt><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>n</kbd></kbd></dt><dd>new</dd></div>
+  <div><dt><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>s</kbd></kbd></dt><dd>save</dd></div>
+  <div><dt><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>o</kbd></kbd></dt><dd>open</dd></div>
+  <div><dt><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>g</kbd></kbd></dt><dd>open selection</dd></div>
+  <div><dt><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>r</kbd></kbd></dt><dd>rename</dd></div>
+  <div><dt><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>c</kbd></kbd></dt><dd>copy</dd></div>
+  <div><dt><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>v</kbd></kbd></dt><dd>paste</dd></div>
+  <div><dt><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>x</kbd></kbd></dt><dd>cut</dd></div>
+  <div><dt><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>h</kbd></kbd></dt><dd>toggle syntax</dd></div>
+  <div><dt><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>f</kbd></kbd></dt><dd>toggle font</dd></div>
+</dl>
 
 <hr />
 
@@ -144,7 +144,7 @@
 
 <img src='../media/content/projects/left_03.png' class='detail'/>
 
-<p>To save a file, press <b>ctrl+s</b>.</p>
+<p>To save a file, press <kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>s</kbd></kbd>.</p>
 
 <p>At the top left corner of the window is a diamond shape, it changes color to indicate whether or not you have unsaved changes.</p>
 <hr />

--- a/src/inc/nasu_guide.htm
+++ b/src/inc/nasu_guide.htm
@@ -33,7 +33,7 @@
 <h3><a id='controls'>Controls</a></h3>
 
 <dl class='col2 shortcut-list' aria-labelledby='controls'>
-  <div><dt><kbd class='shortcut'>arrows</kbd></dt><dd>move selection</dd></div>
+  <div><dt><kbd class='shortcut'><kbd>←</kbd> <kbd>↑</kbd> <kbd>→</kbd> <kbd>↓</kbd></kbd></kbd></dt><dd>move selection</dd></div>
   <div><dt><kbd class='shortcut'>spacebar</kbd></dt><dd>toggle zoom</dd></div>
   <div><dt><kbd class='shortcut'>enter</kbd></dt><dd>insert tile</dd></div>
   <div><dt><kbd class='shortcut'>backspace</kbd></dt><dd>delete tile</dd></div>

--- a/src/inc/nasu_guide.htm
+++ b/src/inc/nasu_guide.htm
@@ -33,29 +33,29 @@
 <h3><a id='controls'>Controls</a></h3>
 
 <ul class='col2'>
-  <li><code class='shortcut'>arrows</code> move selection</li>
-  <li><code class='shortcut'>spacebar</code> toggle zoom</li>
-  <li><code class='shortcut'>enter</code> insert tile</li>
-  <li><code class='shortcut'>backspace</code> delete tile</li>
-  <li><code class='shortcut'>escape</code> reset selection</li>
-  <li><code class='shortcut'>left-click</code> select/brush</li>
-  <li><code class='shortcut'>right-click</code> erase</li>
-  <li><code class='shortcut'>1 2 3 4</code> select color</li>
-  <li><code class='shortcut'>q w e</code> select tool</li>
-  <li><code class='shortcut'>ctrl+n</code> new</li>
-  <li><code class='shortcut'>ctrl+s</code> save</li>
-  <li><code class='shortcut'>ctrl+o</code> open</li>
-  <li><code class='shortcut'>ctrl+r</code> rename</li>
-  <li><code class='shortcut'>ctrl+c</code> copy</li>
-  <li><code class='shortcut'>ctrl+v</code> paste</li>
-  <li><code class='shortcut'>ctrl+x</code> quit</li>
+  <li><kbd class='shortcut'>arrows</kbd> move selection</li>
+  <li><kbd class='shortcut'>spacebar</kbd> toggle zoom</li>
+  <li><kbd class='shortcut'>enter</kbd> insert tile</li>
+  <li><kbd class='shortcut'>backspace</kbd> delete tile</li>
+  <li><kbd class='shortcut'>escape</kbd> reset selection</li>
+  <li><kbd class='shortcut'>left-click</kbd> select/brush</li>
+  <li><kbd class='shortcut'>right-click</kbd> erase</li>
+  <li><kbd class='shortcut'><kbd>1</kbd> <kbd>2</kbd> <kbd>3</kbd> <kbd>4</kbd></kbd> select color</li>
+  <li><kbd class='shortcut'><kbd>q</kbd> <kbd>w</kbd> <kbd>e</kbd></kbd> select tool</li>
+  <li><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>n</kbd></kbd> new</li>
+  <li><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>s</kbd></kbd> save</li>
+  <li><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>o</kbd></kbd> open</li>
+  <li><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>r</kbd></kbd> rename</li>
+  <li><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>c</kbd></kbd> copy</li>
+  <li><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>v</kbd></kbd> paste</li>
+  <li><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>x</kbd></kbd> quit</li>
 </ul>
 
 <h3><a id='uxncontrols'>Uxn-specific controls</a></h3>
 <ul>
-  <li><code class='shortcut'>f1</code> scale screen</li>
-  <li><code class='shortcut'>f2</code> debugger</li>
-  <li><code class='shortcut'>f3</code> screenshot</li>
+  <li><kbd class='shortcut'>f1</kbd> scale screen</li>
+  <li><kbd class='shortcut'>f2</kbd> debugger</li>
+  <li><kbd class='shortcut'>f3</kbd> screenshot</li>
 </ul>
 
 
@@ -192,7 +192,7 @@
 
 <p>This tool can set focus on a specific tile. Choosing a tile with the select tool changes the information in the blend view, pre view, zoom view and data view.</p>
 
-<p>With the select tool, it is possible to copy and paste entire sprites from one place to the other, or from one Nasu instance to another. To do this, select a sprite that spans multiple tiles and press <b>ctrl+c</b>. Navigate to the desired spot on the canvas, with your cursor select the tile width of your sprite and then press <b>ctrl+v</b>. Your sprite will be pasted on the canvas as is. It is also possible to paste the sprite already pre-broken down on a line, to do this, while on the canvas make a horizontal selection exceeding the number of tiles that make up the sprite, and press <b>ctrl+v</b>.</p>
+<p>With the select tool, it is possible to copy and paste entire sprites from one place to the other, or from one Nasu instance to another. To do this, select a sprite that spans multiple tiles and press <kbd class="shortcut"><kbd>ctrl</kbd> + <kbd>c</kbd></kbd>. Navigate to the desired spot on the canvas, with your cursor select the tile width of your sprite and then press <kbd class="shortcut"><kbd>ctrl</kbd> + <kbd>v</kbd></kbd>. Your sprite will be pasted on the canvas as is. It is also possible to paste the sprite already pre-broken down on a line, to do this, while on the canvas make a horizontal selection exceeding the number of tiles that make up the sprite, and press <kbd class="shortcut"><kbd>ctrl</kbd> + <kbd>v</kbd></kbd>.</p>
 
 <hr />
 

--- a/src/inc/nasu_guide.htm
+++ b/src/inc/nasu_guide.htm
@@ -32,31 +32,31 @@
 
 <h3><a id='controls'>Controls</a></h3>
 
-<ul class='col2'>
-  <li><kbd class='shortcut'>arrows</kbd> move selection</li>
-  <li><kbd class='shortcut'>spacebar</kbd> toggle zoom</li>
-  <li><kbd class='shortcut'>enter</kbd> insert tile</li>
-  <li><kbd class='shortcut'>backspace</kbd> delete tile</li>
-  <li><kbd class='shortcut'>escape</kbd> reset selection</li>
-  <li><kbd class='shortcut'>left-click</kbd> select/brush</li>
-  <li><kbd class='shortcut'>right-click</kbd> erase</li>
-  <li><kbd class='shortcut'><kbd>1</kbd> <kbd>2</kbd> <kbd>3</kbd> <kbd>4</kbd></kbd> select color</li>
-  <li><kbd class='shortcut'><kbd>q</kbd> <kbd>w</kbd> <kbd>e</kbd></kbd> select tool</li>
-  <li><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>n</kbd></kbd> new</li>
-  <li><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>s</kbd></kbd> save</li>
-  <li><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>o</kbd></kbd> open</li>
-  <li><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>r</kbd></kbd> rename</li>
-  <li><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>c</kbd></kbd> copy</li>
-  <li><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>v</kbd></kbd> paste</li>
-  <li><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>x</kbd></kbd> quit</li>
-</ul>
+<dl class='col2 shortcut-list' aria-labelledby='controls'>
+  <div><dt><kbd class='shortcut'>arrows</kbd></dt><dd>move selection</dd></div>
+  <div><dt><kbd class='shortcut'>spacebar</kbd></dt><dd>toggle zoom</dd></div>
+  <div><dt><kbd class='shortcut'>enter</kbd></dt><dd>insert tile</dd></div>
+  <div><dt><kbd class='shortcut'>backspace</kbd></dt><dd>delete tile</dd></div>
+  <div><dt><kbd class='shortcut'>escape</kbd></dt><dd>reset selection</dd></div>
+  <div><dt><kbd class='shortcut'>left-click</kbd></dt><dd>select/brush</dd></div>
+  <div><dt><kbd class='shortcut'>right-click</kbd></dt><dd>erase</dd></div>
+  <div><dt><kbd class='shortcut'><kbd>1</kbd> <kbd>2</kbd> <kbd>3</kbd> <kbd>4</kbd></kbd></dt><dd>select color</dd></div>
+  <div><dt><kbd class='shortcut'><kbd>q</kbd> <kbd>w</kbd> <kbd>e</kbd></kbd></dt><dd>select tool</dd></div>
+  <div><dt><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>n</kbd></kbd></dt><dd>new</dd></div>
+  <div><dt><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>s</kbd></kbd></dt><dd>save</dd></div>
+  <div><dt><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>o</kbd></kbd></dt><dd>open</dd></div>
+  <div><dt><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>r</kbd></kbd></dt><dd>rename</dd></div>
+  <div><dt><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>c</kbd></kbd></dt><dd>copy</dd></div>
+  <div><dt><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>v</kbd></kbd></dt><dd>paste</dd></div>
+  <div><dt><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>x</kbd></kbd></dt><dd>quit</dd></div>
+</dl>
 
 <h3><a id='uxncontrols'>Uxn-specific controls</a></h3>
-<ul>
-  <li><kbd class='shortcut'>f1</kbd> scale screen</li>
-  <li><kbd class='shortcut'>f2</kbd> debugger</li>
-  <li><kbd class='shortcut'>f3</kbd> screenshot</li>
-</ul>
+<dl class='shortcut-list' aria-labelledby='uxncontrols'>
+  <div><dt><kbd class='shortcut'>f1</kbd></dt><dd>scale screen</dd></div>
+  <div><dt><kbd class='shortcut'>f2</kbd></dt><dd>debugger</dd></div>
+  <div><dt><kbd class='shortcut'>f3</kbd></dt><dd>screenshot</dd></div>
+</dl>
 
 
 <h3><a id='renaming'>Renaming a file</a></h3>

--- a/src/inc/nasu_guide.htm
+++ b/src/inc/nasu_guide.htm
@@ -33,7 +33,7 @@
 <h3><a id='controls'>Controls</a></h3>
 
 <dl class='col2 shortcut-list' aria-labelledby='controls'>
-  <div><dt><kbd class='shortcut'><kbd>←</kbd> <kbd>↑</kbd> <kbd>→</kbd> <kbd>↓</kbd></kbd></kbd></dt><dd>move selection</dd></div>
+  <div><dt><kbd class='shortcut'><kbd>←</kbd> <kbd>↑</kbd> <kbd>→</kbd> <kbd>↓</kbd></kbd></dt><dd>move selection</dd></div>
   <div><dt><kbd class='shortcut'>spacebar</kbd></dt><dd>toggle zoom</dd></div>
   <div><dt><kbd class='shortcut'>enter</kbd></dt><dd>insert tile</dd></div>
   <div><dt><kbd class='shortcut'>backspace</kbd></dt><dd>delete tile</dd></div>

--- a/src/inc/noodle.htm
+++ b/src/inc/noodle.htm
@@ -51,7 +51,7 @@
 
 <dl class='col2 shortcut-list' aria-labelledby='controls'>
   <div><dt><kbd class='shortcut'><kbd>right-click</kbd> and <kbd>escape</kbd></kbd></dt><dd>erase</dd></div>
-  <div><dt><kbd class='shortcut'>arrows</kbd></dt><dd>move zoom</dd></div>
+  <div><dt><kbd class='shortcut'><kbd>←</kbd> <kbd>↑</kbd> <kbd>→</kbd> <kbd>↓</kbd></kbd></dt><dd>move zoom</dd></div>
   <div><dt><kbd class='shortcut'><kbd>spacebar</kbd> or <kbd>shift</kbd></kbd></dt><dd>toggle zoom</dd></div>
   <div><dt><kbd class='shortcut'>tab</kbd></dt><dd>invert image</dd></div>
   <div><dt><kbd class='shortcut'>backspace</kbd></dt><dd>blank canvas</dd></div>

--- a/src/inc/noodle.htm
+++ b/src/inc/noodle.htm
@@ -50,34 +50,34 @@
 <h3><a id='controls'>Controls</a></h3>
 
 <ul class='col2'>
-  <li><code class='shortcut'>right-click and escape</code> erase</li>
-  <li><code class='shortcut'>arrows</code> move zoom</li>
-  <li><code class='shortcut'>spacebar or shift</code> toggle zoom</li>
-  <li><code class='shortcut'>tab</code> invert image</li>
-  <li><code class='shortcut'>backspace</code> blank canvas</li>
-  <li><code class='shortcut'>1-8</code> select pattern</li>
-  <li><code class='shortcut'>[ ]</code> select brush size</li>
-  <li><code class='shortcut'>ctrl+n</code> clear</li>
-  <li><code class='shortcut'>ctrl+r</code> rename</li>
-  <li><code class='shortcut'>ctrl+o</code> load</li>
-  <li><code class='shortcut'>ctrl+s</code> save</li>
-  <li><code class='shortcut'>e</code> line tool</li>
-  <li><code class='shortcut'>q</code> pen tool</li>
-  <li><code class='shortcut'>w</code> brush tool</li>
-  <li><code class='shortcut'>t</code> rectangle tool</li>
-  <li><code class='shortcut'>r</code> magic tool</li>
-  <li><code class='shortcut'>y</code> zoom tool</li>
+  <li><kbd class='shortcut'><kbd>right-click</kbd> and <kbd>escape</kbd></kbd> erase</li>
+  <li><kbd class='shortcut'>arrows</kbd> move zoom</li>
+  <li><kbd class='shortcut'><kbd>spacebar</kbd> or <kbd>shift</kbd></kbd> toggle zoom</li>
+  <li><kbd class='shortcut'>tab</kbd> invert image</li>
+  <li><kbd class='shortcut'>backspace</kbd> blank canvas</li>
+  <li><kbd class='shortcut'><kbd>1</kbd> - <kbd>8</kbd></kbd> select pattern</li>
+  <li><kbd class='shortcut'><kbd>[</kbd> <kbd>]</kbd></kbd> select brush size</li>
+  <li><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>n</kbd></kbd> clear</li>
+  <li><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>r</kbd></kbd> rename</li>
+  <li><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>o</kbd></kbd> load</li>
+  <li><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>s</kbd></kbd> save</li>
+  <li><kbd class='shortcut'>e</kbd> line tool</li>
+  <li><kbd class='shortcut'>q</kbd> pen tool</li>
+  <li><kbd class='shortcut'>w</kbd> brush tool</li>
+  <li><kbd class='shortcut'>t</kbd> rectangle tool</li>
+  <li><kbd class='shortcut'>r</kbd> magic tool</li>
+  <li><kbd class='shortcut'>y</kbd> zoom tool</li>
 </ul>
 
 <h3><a id='renaming'>Re-naming a file</a></h3>
 
 <p>The default filename reads <b>untitled.icn</b>. To change it, click on the text. The text field will blink, allowing you to type a new file name.</p>
 
-<p>Press <b>ctrl+shift+r</b> to erase filename, rather than using backspace.</p>
+<p>Press <kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>r</kbd></kbd> to erase filename, rather than using backspace.</p>
 
 <h3><a id='invert'>Invert images</a></h3>
 
-<p>To invert the image, press tab.</p>
+<p>To invert the image, press <kbd class='shortcut'>tab</kbd>.</p>
 
 <h3><a id='saving'>Saving file</a></h3>
 
@@ -115,23 +115,23 @@
 
 <h3><a id='resize'>Resize canvas</a></h3>
 
-<p>To resize the canvas, pull on the black corner on the bottom right of the window. Adjusting the canvas size changes the number on top, next to the pattern menu. It's also possible to resize it by clicking <b>alt+arrows</b>.</p>
+<p>To resize the canvas, pull on the black corner on the bottom right of the window. Adjusting the canvas size changes the number on top, next to the pattern menu. It's also possible to resize it by clicking <kbd class='shortcut'><kbd>alt</kbd> + <kbd>arrows</kbd></kbd>.</p>
 
 <p>Only resize the canvas at the start of a project, otherwise it will mess up your drawing.</p>
 
 <h3><a id='erase'>Erase</a></h3>
 
-<p>It's possible to use the following tools to erase: brush tool, line tool, pen tool and rectangle tool. Select the tool you wish to use as an eraser, press <b>escape key</b> to toggle to erase mode, or click on a brush size in the top menu until it switches to a shape with a contour rather than one that is opaque.</p>
+<p>It's possible to use the following tools to erase: brush tool, line tool, pen tool and rectangle tool. Select the tool you wish to use as an eraser, press <kbd class='shortcut'>escape</kbd> key to toggle to erase mode, or click on a brush size in the top menu until it switches to a shape with a contour rather than one that is opaque.</p>
 
 <p>It's also possible to erase using a pattern.</p>
 
-<p>To erase the whole canvas press <b>backspace</b>.</p>
+<p>To erase the whole canvas press <kbd class='shortut'>backspace</kbd>.</p>
 
 <h3><a id='patterns'>Pattern menu</a></h3>
 
 <img src='../media/content/projects/noodle_05.png' class='detail' />
 
-<p>A set of 8 patterns to draw with. To change pattern select numbers 1-8.</p>
+<p>A set of 8 patterns to draw with. To change pattern select numbers <kbd class='shortut'><kbd>1</kbd> - <kbd>8</kbd></kbd>.</p>
 
 <p>The default pattern is black. Select the brush, or rectangle tool first, and then a pattern.</p>
 
@@ -141,7 +141,7 @@
 
 <img src='../media/content/projects/noodle_06.png' class='detail' />
 
-<p>A tool to draw thin single-pixel drawings on the canvas. The shortcut to select the pen tool is <b>q</b>.</p>
+<p>A tool to draw thin single-pixel drawings on the canvas. The shortcut to select the pen tool is <kbd class='shortut'>q</kbd>.</p>
 
 <p>This tool can only ever be 1 pixel. Erase by right-clicking.</p>
 
@@ -151,9 +151,9 @@
 
 <img src='../media/content/projects/noodle_07.png' class='detail' />
 
-<p>A tool to draw brush-like strokes on the canvas. To increase or decrease brush size use the box brackets <b>[ ]</b>. The shortcut to select the brush tool is <b>w</b>. Erase by right-clicking.</p>
+<p>A tool to draw brush-like strokes on the canvas. To increase or decrease brush size use the box brackets <kbd class='shortcut'><kbd>[</kbd> <kbd>]</kbd></kbd>. The shortcut to select the brush tool is <kbd class='shortcut'>w</kbd>. Erase by right-clicking.</p>
 
-<p>To draw using a pattern, select a style from the pattern menu and toggle between each pattern using the numbers 1-8.</p>
+<p>To draw using a pattern, select a style from the pattern menu and toggle between each pattern using the numbers <kbd class='shortcut'><kbd>1</kbd> - <kbd>8</kbd></kbd>.</p>
 
 <hr />
 
@@ -171,7 +171,7 @@
 
 <img src='../media/content/projects/noodle_09.png' class='detail' />
 
-<p>A tool to clean up lines. The shortcut to select the pen tool is <b>r</b></p>
+<p>A tool to clean up lines. The shortcut to select the pen tool is <kbd class='shortcut'>r</kbd></p>
 
 <p>This tool is useful to remove excess pixels when drawing sharp edges with the pen tool.</p>
 
@@ -181,7 +181,7 @@
 
 <img src='../media/content/projects/noodle_10.png' class='detail' />
 
-<p>A tool to draw rectangles on a canvas. The rectangle tool shortcut is <b>t</b>.</p>
+<p>A tool to draw rectangles on a canvas. The rectangle tool shortcut is <kbd class='shortcut'>t</kbd>.</p>
 
 <p>To draw using a pattern, select a style from the right menu.</p>
 
@@ -191,9 +191,9 @@
 
 <img src='../media/content/projects/noodle_11.png' class='detail' />
 
-<p>For a more detailed view of a drawing, select the zoom tool (shortcut is <b>y</b>), or press on the <b>spacebar</b> or <b>shift</b>. The magnifying glass has a little circle next to it when zoomed in.</p>
+<p>For a more detailed view of a drawing, select the zoom tool (shortcut is <kbd class='shortcut'>y</kbd>), or press on the <kbd class='shortcut'>spacebar</kbd> or <kbd class='shortcut'>shift</kbd>. The magnifying glass has a little circle next to it when zoomed in.</p>
 
-<p>Use the arrows to move around the canvas while zoomed in, and press the <b>spacebar</b>, or <b>shift</b> key to return to the normal view. If you toggle zoom again after having moved with the arrows, Noodle will remember this new position and zoom in on that exact point on the canvas. If you want to zoom in on another far-away part of the canvas, select the zoom tool and click on the area you wish to modify.</p>
+<p>Use the arrows to move around the canvas while zoomed in, and press the <kbd class='shortcut'>spacebar</kbd>, or <kbd class='shortcut'>shift</kbd> key to return to the normal view. If you toggle zoom again after having moved with the arrows, Noodle will remember this new position and zoom in on that exact point on the canvas. If you want to zoom in on another far-away part of the canvas, select the zoom tool and click on the area you wish to modify.</p>
 
 <hr />
 
@@ -203,7 +203,7 @@
 
 <p>To create small animations there are basic tools to use. To add frames, click on the number on the right. This number counts up the number of frames in a project. The size of the canvas limits the number of frames, and Noodle restricts the allowable amount automatically. For more frames, resize the canvas to a smaller size.</p>
 
-<p>The number on the left is your animation frames. On 0, draw the first frame, the another one the second, third etc. Clicking on the number, or pressing <b>enter</b>, will cycle through your frames.</p>
+<p>The number on the left is your animation frames. On 0, draw the first frame, the another one the second, third etc. Clicking on the number, or pressing <kbd class='shortcut'>enter</kbd>, will cycle through your frames.</p>
 
 <p>To clear the animation, you must clear all layers individually.</p>
 

--- a/src/inc/noodle.htm
+++ b/src/inc/noodle.htm
@@ -49,25 +49,25 @@
 
 <h3><a id='controls'>Controls</a></h3>
 
-<ul class='col2'>
-  <li><kbd class='shortcut'><kbd>right-click</kbd> and <kbd>escape</kbd></kbd> erase</li>
-  <li><kbd class='shortcut'>arrows</kbd> move zoom</li>
-  <li><kbd class='shortcut'><kbd>spacebar</kbd> or <kbd>shift</kbd></kbd> toggle zoom</li>
-  <li><kbd class='shortcut'>tab</kbd> invert image</li>
-  <li><kbd class='shortcut'>backspace</kbd> blank canvas</li>
-  <li><kbd class='shortcut'><kbd>1</kbd> - <kbd>8</kbd></kbd> select pattern</li>
-  <li><kbd class='shortcut'><kbd>[</kbd> <kbd>]</kbd></kbd> select brush size</li>
-  <li><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>n</kbd></kbd> clear</li>
-  <li><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>r</kbd></kbd> rename</li>
-  <li><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>o</kbd></kbd> load</li>
-  <li><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>s</kbd></kbd> save</li>
-  <li><kbd class='shortcut'>e</kbd> line tool</li>
-  <li><kbd class='shortcut'>q</kbd> pen tool</li>
-  <li><kbd class='shortcut'>w</kbd> brush tool</li>
-  <li><kbd class='shortcut'>t</kbd> rectangle tool</li>
-  <li><kbd class='shortcut'>r</kbd> magic tool</li>
-  <li><kbd class='shortcut'>y</kbd> zoom tool</li>
-</ul>
+<dl class='col2 shortcut-list' aria-labelledby='controls'>
+  <div><dt><kbd class='shortcut'><kbd>right-click</kbd> and <kbd>escape</kbd></kbd></dt><dd>erase</dd></div>
+  <div><dt><kbd class='shortcut'>arrows</kbd></dt><dd>move zoom</dd></div>
+  <div><dt><kbd class='shortcut'><kbd>spacebar</kbd> or <kbd>shift</kbd></kbd></dt><dd>toggle zoom</dd></div>
+  <div><dt><kbd class='shortcut'>tab</kbd></dt><dd>invert image</dd></div>
+  <div><dt><kbd class='shortcut'>backspace</kbd></dt><dd>blank canvas</dd></div>
+  <div><dt><kbd class='shortcut'><kbd>1</kbd> - <kbd>8</kbd></kbd></dt><dd>select pattern</dd></div>
+  <div><dt><kbd class='shortcut'><kbd>[</kbd> <kbd>]</kbd></kbd></dt><dd>select brush size</dd></div>
+  <div><dt><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>n</kbd></kbd></dt><dd>clear</dd></div>
+  <div><dt><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>r</kbd></kbd></dt><dd>rename</dd></div>
+  <div><dt><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>o</kbd></kbd></dt><dd>load</dd></div>
+  <div><dt><kbd class='shortcut'><kbd>ctrl</kbd> + <kbd>s</kbd></kbd></dt><dd>save</dd></div>
+  <div><dt><kbd class='shortcut'>e</kbd></dt><dd>line tool</dd></div>
+  <div><dt><kbd class='shortcut'>q</kbd></dt><dd>pen tool</dd></div>
+  <div><dt><kbd class='shortcut'>w</kbd></dt><dd>brush tool</dd></div>
+  <div><dt><kbd class='shortcut'>t</kbd></dt><dd>rectangle tool</dd></div>
+  <div><dt><kbd class='shortcut'>r</kbd></dt><dd>magic tool</dd></div>
+  <div><dt><kbd class='shortcut'>y</kbd></dt><dd>zoom tool</dd></div>
+</dl>
 
 <h3><a id='renaming'>Re-naming a file</a></h3>
 

--- a/src/inc/uxn_guide.htm
+++ b/src/inc/uxn_guide.htm
@@ -35,19 +35,19 @@ bin/uxnemu path/to/example.rom
 <h3><a id='controls'>Emulator Controls</a></h3>
 
 <ul>
-  <li><code class='shortcut'>F1</code> toggle zoom</li>
-  <li><code class='shortcut'>F2</code> toggle debugger</li>
-  <li><code class='shortcut'>F3</code> take screenshot</li>
-  <li><code class='shortcut'>F4</code> load launcher.rom</li>
+  <li><kbd class='shortcut'>F1</kbd> toggle zoom</li>
+  <li><kbd class='shortcut'>F2</kbd> toggle debugger</li>
+  <li><kbd class='shortcut'>F3</kbd> take screenshot</li>
+  <li><kbd class='shortcut'>F4</kbd> load launcher.rom</li>
 </ul>
 
 <h4>Buttons</h4>
 
 <ul>
-  <li>L-CTRL A</li>
-  <li>L-ALT B</li>
-  <li>L-SHIFT SEL</li>
-  <li>HOME START</li>
+  <li><kbd class='shortcut'>L-Ctrl</kbd> A</li>
+  <li><kbd class='shortcut'>L-Alt</kbd> B</li>
+  <li><kbd class='shortcut'>L-Shift</kbd> Select</li>
+  <li><kbd class='shortcut'>Home</kbd> Start</li>
 </ul>
 
 <h4><a id='other'>Other Systems</a></h4>

--- a/src/inc/uxn_guide.htm
+++ b/src/inc/uxn_guide.htm
@@ -34,21 +34,21 @@ bin/uxnemu path/to/example.rom
 
 <h3><a id='controls'>Emulator Controls</a></h3>
 
-<ul>
-  <li><kbd class='shortcut'>F1</kbd> toggle zoom</li>
-  <li><kbd class='shortcut'>F2</kbd> toggle debugger</li>
-  <li><kbd class='shortcut'>F3</kbd> take screenshot</li>
-  <li><kbd class='shortcut'>F4</kbd> load launcher.rom</li>
+<dl class='shortcut-list' aria-labelledby='controls'>
+  <div><dt><kbd class='shortcut'>F1</kbd></dt><dd>toggle zoom</dd></div>
+  <div><dt><kbd class='shortcut'>F2</kbd></dt><dd>toggle debugger</dd></div>
+  <div><dt><kbd class='shortcut'>F3</kbd></dt><dd>take screenshot</dd></div>
+  <div><dt><kbd class='shortcut'>F4</kbd></dt><dd>load launcher.rom</dd></div>
 </ul>
 
 <h4>Buttons</h4>
 
-<ul>
-  <li><kbd class='shortcut'>L-Ctrl</kbd> A</li>
-  <li><kbd class='shortcut'>L-Alt</kbd> B</li>
-  <li><kbd class='shortcut'>L-Shift</kbd> Select</li>
-  <li><kbd class='shortcut'>Home</kbd> Start</li>
-</ul>
+<dl class='shortcut-list'>
+  <div><dt><kbd class='shortcut'>L-Ctrl</kbd></dt><dd>A</dd></div>
+  <div><dt><kbd class='shortcut'>L-Alt</kbd></dt><dd>B</dd></div>
+  <div><dt><kbd class='shortcut'>L-Shift</kbd></dt><dd>Select</dd></div>
+  <div><dt><kbd class='shortcut'>Home</kbd></dt><dd>Start</dd></div>
+</dl>
 
 <h4><a id='other'>Other Systems</a></h4>
 


### PR DESCRIPTION
In [left](https://100r.co/site/left.html), [nasu_guide](https://100r.co/site/nasu_guide.html), [noodle](https://100r.co/site/noodle.html), and [uxn_guide](https://100r.co/site/uxn_guide.html) the [`<ul>`](https://html.spec.whatwg.org/multipage/grouping-content.html#the-ul-element)s containing keyboard shortcuts have been replaced by [`<dl>`](https://html.spec.whatwg.org/multipage/grouping-content.html#the-dl-element)s containing [`<dt>`](https://html.spec.whatwg.org/multipage/grouping-content.html#the-dt-element)[`<dd>`](https://html.spec.whatwg.org/multipage/grouping-content.html#the-dd-element) pairs for improved HTML semantics (name-value pairs).

The keyboard shortcut strings themselves have been wrapped in [`<kbd>`](https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-kbd-element) elements for improved HTML semantics.