### PR TITLE
Fix log page

### DIFF
--- a/src/inc/log.htm
+++ b/src/inc/log.htm
@@ -37,7 +37,7 @@
     <li><b>{Nasu}</b>, added menu bar.</li>
     <li><b>{Noodle}</b>, added menu bar.</li>
     <li><b>100r.co</b>, updated {boom tent}, and added {lpg refit} (backdated update).</li>
-</u>
+</ul>
 
 <h3>News</h3>
 
@@ -127,7 +127,7 @@
     <li><b>{Grimgrains}</b>, added a new recipe: <a href='https://grimgrains.com/site/bean_chili.html' target='_blank'>Bean chili</a>.</li>
     <li><b>{Thousand Rooms}</b>, released <a href='https://hundredrabbits.itch.io/thousand-rooms/devlog/352502/catalan-version' target='_blank'>Catalan version</a>, a translation by Dani Sevilla.</li>
     <li><b>100r.co</b>, added a new project: {gravity water filter}.</li>
-    <li><b>{Uxn}</b>, Cancel(Andrew R.) released a new version of <a href='https://github.com/randrew/uxn32/releases' target='_blank'>uxn32</a> with complete step debugging tools. Added <a href='https://wiki.xxiivv.com/site/varvara.html' target='_blank'>new art</a> for the Varvara docs.</a>.</li>
+    <li><b>{Uxn}</b>, Cancel(Andrew R.) released a new version of <a href='https://github.com/randrew/uxn32/releases' target='_blank'>uxn32</a> with complete step debugging tools. Added <a href='https://wiki.xxiivv.com/site/varvara.html' target='_blank'>new art</a> for the Varvara docs.</li>
     <li><b>{Orca}</b>, implemented <a href='https://www.youtube.com/watch?v=oXmKJ_tYg34&feature=youtu.be' target='_blank'>injections</a>(YouTube), and <a href='https://www.youtube.com/watch?v=xIBTzswUmzY' target='_blank'>J and Y wiring</a>(YouTube).</li>
     <li><b>Toys</b>, released {Uxn} versions of <a href='https://merveilles.town/@neauoire/107868108987441439' target='_blank'>Minesweeper</a>(Mastodon), and <a href='https://wiki.xxiivv.com/site/wireworld.html' target='_blank'>Wireworld</a>.</li>
 </ul>
@@ -192,7 +192,7 @@
 
 <p>In other news, we had an interview with the founder of <a href='https://sourcehut.org/' target='_blank'>Sourcehut</a>, read it <a href='https://sourcehut.org/blog/2021-12-08-100-rabbits-interview/' target='_blank'>here</a>. Also, our good friend Alderwick make us a very cool <a href='https://www.youtube.com/watch?v=i83FTGk24JM' target='_blank'>gift</a>(YouTube).</p>
 
-<h3>Pino book club</h2>
+<h3>Pino book club</h3>
 
 <p>We're reading <b><a href='https://fantomeszine.com/' target='_blank'>Fantômes: Issue 1</a></b>, with work by 18 talented artists, put together by <a href='https://ritualdust.com/' target='_blank'>Lizbeth</a>. It is a eerie, and gorgeous zine, we strongly recommend the Mike Wolf version.</p>
 
@@ -212,7 +212,7 @@
 
 <p>November was a very rainy month in Victoria, a perfect time for experiments in the galley. We are growing Lion's Mane mushrooms currently (a first for us), and we are continuing to lacto-ferment vegetables like kohlrabi, turnips, daikon, cauliflower and red onion. To learn how to do it, see our <a href='https://grimgrains.com/site/lactofermentation.html' target='_blank'>guide to lactofermentation</a>.</p>
 
-<h3>Pino book club</h2>
+<h3>Pino book club</h3>
 
 <p>We're reading <b>The Summer Book</b> by Tove Jansson (it's such a lovely book).</p>
 
@@ -221,7 +221,7 @@
     <li><b>{Donsol}</b>, ported our Famicom(6502) code to Varvara({Uxn}).</li>
     <li><b>{Uxn}</b>, wrote a <a href='https://wiki.xxiivv.com/site/uxntal_reference.html' target='_blank'>reference guide</a> and created a list of <a href='https://github.com/hundredrabbits/awesome-uxn' target='_blank'>community projects</a>.</li>
     <li><b>{Noodle}</b>, added guides for the line and rectangle tool and <a href='https://100r.co/site/noodle.html#controls'>updated shortcuts</a> in the documentation.</li>
-    <li><b>{Grimgrains}</b>, optimized images and published a <a href='https://grimgrains.com/site/chunky_apple_jam.html' target='_blank'>Chunky Apple Jam<a> recipe.</li>
+    <li><b>{Grimgrains}</b>, optimized images and published a <a href='https://grimgrains.com/site/chunky_apple_jam.html' target='_blank'>Chunky Apple Jam recipe.</li>
     <li><b>100r</b>, optimized images (see Rek's <a href='https://kokorobot.ca/site/leanimages.html'>notes</a>). Added new pages: {boom_tent}, {grinder} and {small_space}.</li>
     <li><b>{Left}</b>, optimized code.</li>
     <li><b>{Nasu}</b>, fixed crashing bug with large selections.</li>
@@ -235,7 +235,7 @@
 
 <p>See Devine's <a href='https://merveilles.town/web/statuses/107033448028097574' target='_blank'>daily drawings series</a> for October.</p>
 
-<h3>Pino book club</h2>
+<h3>Pino book club</h3>
 
 <p>We're continuing our readings of <b>The Stories of Ray Bradbury</b> by Ray Bradbury. Favorite shorts this month include <b>The Long Rain</b>, <b>The City</b> and <b>Kaleidoscope</b>.</p>
 
@@ -260,7 +260,7 @@
 
 <p>Our friends at Compudanzas have released <a href='https://compudanzas.net/uxn_tutorial_day_6.html' target='_blank'>part 6</a> of their <a href='https://compudanzas.net/uxn_tutorial.html' target='_blank'>Introduction to Uxn Programming tutorial</a>. This new chapter basically shows you how to build Pong!</p>
 
-<h3>Pino book club</h2>
+<h3>Pino book club</h3>
 
 <p>We started reading <b>The Stories of Ray Bradbury</b> by Ray Bradbury. Favorite shorts so far include <b>There Will Come Soft Rains</b>, <b>The Coffin</b> and <b>There Was an Old Woman</b>.</p>
 
@@ -285,7 +285,7 @@
 
 <p>Our friends at Compudanzas have released part <a href='https://compudanzas.net/uxn_tutorial_day_3.html' target='_blank'>3</a>, <a href='https://compudanzas.net/uxn_tutorial_day_4.html' target='_blank'>4</a> and <a href='https://compudanzas.net/uxn_tutorial_day_5.html' target='_blank'>5</a> of their <a href='https://compudanzas.net/uxn_tutorial.html' target='_blank'>Introduction to Uxn Programming tutorial</a>.</p>
 
-<h3>Pino book club</h2>
+<h3>Pino book club</h3>
 
 <p>Help. We still haven't finished <b>The Swarm</b> by Frank Schatzing. It is terrible, but we can't stop.</p>
 
@@ -311,7 +311,7 @@
 
 <p>If you missed Devine's performance at <a href='https://flashcrash.net/' target='_blank'>Flash Crash</a>, you can watch it <a href='https://youtu.be/N_00rAa8o24' target='_blank'>here</a>.</p>
 
-<h3>Pino book club</h2>
+<h3>Pino book club</h3>
 
 <p>We're reading <b>Mingming & the Art of Minimal Ocean Sailing</b> by Roger Taylor and <b>The Swarm</b> by Frank Schatzing.</p>
 
@@ -338,7 +338,7 @@
 
 <p>
 
-<h3>Pino book club</h2>
+<h3>Pino book club</h3>
 
 <p>We're reading <b>Nature as Measure</b> by Wes Jackson, <b>The Strange Last Voyage of Donald Crowhurst</b> by Nicholas Tomalin and Ron Hall and <b>Labyrinths</b> by Jorge Luis Borges.</p>
 
@@ -361,7 +361,7 @@
 
 <p>In Pino related news, we are moving north. First stop, the boatyard. We'll be doing a bunch of changes to the studio this week, like removing and replacing old {thruhulls} and installing a {dry toilet}.</p>
 
-<h3>Pino book club</h2>
+<h3>Pino book club</h3>
 
 <p>We're reading <b>Farenheit 451</b> by Ray Bradbury.</p>
 
@@ -381,7 +381,7 @@
 
 <p>We also finished installing our <a href='https://100r.co/site/woodstove_installation.html' target='_blank'>wood stove</a>. Our timing could have been better (it's summer now), but we'll be able to keep warm while at anchor next winter. We have many projects to do, including the removal and replacement of many {thruhulls} and plumbing, as well as the installation of a {dry toilet}. Looks like Pino will have to come out of the water again this year!</p>
 
-<h3>Pino book club</h2>
+<h3>Pino book club</h3>
 
 <p>We're reading <b>Terre des Hommes</b> by Antoine de Saint-Exupéry and <b>Sylvie and Bruno</b> by Lewis Carroll.</p>
 
@@ -403,7 +403,7 @@
 
 <p>We have received a lot of really good feedback and corrections for our book <a href='https://100r.co/site/busy_doing_nothing.html' target='_blank'>Busy Doing Nothing</a>, thank you for reading it. Rekka has updated their notes on <a href='https://kokorobot.ca/site/pandoc.html' target='_blank'>creating e-books with Pandoc</a> to include exports to epub and mobi (for those interested).</p>
 
-<h3>Pino book club</h2>
+<h3>Pino book club</h3>
 <p>We're reading <b>The Complete Rigger’s Apprentice</b> by Brion Toss and <b>Thinking Forth</b> by Leo Brody.</p>
 
 
@@ -420,7 +420,7 @@
 <p>This month, we released the e-book version of the North Pacific Logbook titled <a href='https://hundredrabbits.itch.io/busy-doing-nothing' target='_blank'>Busy Doing Nothing</a>. The book is 217 pages long, and is available as a PDF, mobi or EPUB. We're happy it's out, and hope that you like it!</p>
 <p>In other news, Esoteric.Codes <a href='https://esoteric.codes/blog/100-rabbits' target='_blank'>interviewed</a> our studio, and we heard that the Toronto Public Library was hosting an <a href='https://twitter.com/hundredrabbits/status/1364419919547228162?s=20' target="_blank">online Orca workshop</a> on March 1st—how cool is that?</p>
 
-<h3>Pino book club</h2>
+<h3>Pino book club</h3>
 <p>We're reading <b>A Sand County Almanac</b> by Aldo Leopold.</p>
 
 
@@ -444,7 +444,7 @@
 
 <p>The extended version of the North Pacific Logbook is now titled <b>Busy Doing Nothing</b>, an hommage to our favorite Ergo Proxy episode. We're still proofreading it, and making final adjustments. Here's what it looks like on a <a href='https://merveilles.town/@neauoire/105498990504618822' target="_blank">Kindle</a>.</p>
 
-<h3>Pino book club</h2>
+<h3>Pino book club</h3>
 
 <p>We're reading <b>What are People for?</b> by Wendell Berry and <b>Anathem</b> by Neal Stephenson.</p>
 


### PR DESCRIPTION
Fix: `</u>` --> `</ul>`. In the final HTML, it was causing the rest of the content to be inside the `ul` tag.

| Before | After|
| ---| ---|
| ![Screen Shot 2022-07-20 at 19 58 10](https://user-images.githubusercontent.com/5835798/180097514-c990ade6-bf1d-4d95-aaa4-859e8645ac80.png) | ![Screen Shot 2022-07-20 at 20 06 41](https://user-images.githubusercontent.com/5835798/180097517-5a421b7e-4582-40f8-a023-a0138b4ba1ec.png) |