### PR TITLE
Fix link to emulators

### DIFF
--- a/src/inc/uxn_guide.htm
+++ b/src/inc/uxn_guide.htm
@@ -56,7 +56,7 @@ bin/uxnemu path/to/example.rom
 
 <p>Uxn can also run on classic consoles and on old electronics. Currently, there are ports(not all are complete) for GBA, Nintendo DS, Playdate, DOS, PS Vita, Raspberri Pi Pico, Teletype, ESP32, Amiga, iOS, STM32, STM32, IBM PC, and many more.</p>
 
-<p>See the <a href='https://github.com/hundredrabbits/awesome-uxn#applications' target='_blank'>full list of emulators</a>.</p>
+<p>See the <a href='https://github.com/hundredrabbits/awesome-uxn#emulators' target='_blank'>full list of emulators</a>.</p>
 
 <h3><a id='help'>Need a hand?</a></h3>
 


### PR DESCRIPTION
It was just pointing to the wrong anchor, so you had to scroll up to get to the emulators. No longer!