### PR TITLE
main.css: Restore keyboard focus indicator

### DIFF
--- a/links/main.css
+++ b/links/main.css
@@ -1,5 +1,4 @@
 
-*:focus         { outline: none}
 ::selection       { background: #eee; opacity:1.0; color:#000; padding:10px; /* Safari */ }
 
 body { background:#fff; color:#000; overflow-x: hidden; font-family: sans-serif; padding:0; margin:0; }


### PR DESCRIPTION
By hiding the outline around elements that receive keyboard focus, users navigating by keyboard won't know which link is focused as they tab through the page. This is a common accessibility issue with websites that heavily customize the browser's default styles.

More info: [Understanding SC 2.4.7: Focus Visible][0]

[0]: https://www.w3.org/WAI/WCAG22/Understanding/focus-visible.html