### PR TITLE
Update induction_cooking.htm

### DIFF
--- a/src/inc/induction_cooking.htm
+++ b/src/inc/induction_cooking.htm
@@ -1,6 +1,6 @@
 <img src='../media/content/cooking/inductioncooktop.jpg' title='our induction cooktop' alt='a photo of a single burner induction cooktop' loading='lazy'>
 
-<p>Induction cooktops are becoming more common on boats. It creates heat rapidly by magnetically accelerating metal molecules in steel, {cast iron cookware} and some stainless steel pots. It transfers 90% of its heat to a pot. They use heat efficiently and because they heat the pot material there is less heat loss. Nearly all of the energy is converted into cooking the food. A downside of IH is the high-power draw, which ranges between 1200-1800W for a single plate.</p>
+<p>Induction cooktops are becoming more common on boats. It creates heat rapidly by magnetically inducing an electric current in steel, {cast iron cookware} and some stainless steel pots. It transfers 90% of its heat to a pot. They use heat efficiently and because they heat the pot material there is less heat loss. Nearly all of the energy is converted into cooking the food. A downside of IH is the high-power draw, which ranges between 1200-1800W for a single plate.</p>
 
 <p>Small diameter pots may not register on the cooktop, if they don't try and put a bigger pot on first, then switch it for the other one. We have to do this for our moka pot, since the cooktop doesn't register anything under 5". Another trick is to put another small pot alongside the other one, but I prefer the 'switch' method.</p>
 


### PR DESCRIPTION
The eddy currents produced by an induction cooker are not the result of accelerating the entire metal atom itself, but of free charges like electrons able to transmit electric currents. Additionally, metals like steel are not actually composed of metal molecules. A molecule is a discrete collection of atoms held together by chemical bonds, like H2O. So I think it's safer just to leave it more vaguely phrased.