### PR TITLE
Improve mobile navigation

### DIFF
--- a/links/main.css
+++ b/links/main.css
@@ -6,6 +6,8 @@ body { background:#fff; color:#000; overflow-x: hidden; font-family: sans-serif;
 header { padding: 45px; }
 header a img {}
 
+nav { display: none; }
+main + nav { display: block; }
 nav { padding: 0px 45px; float: left; }
 nav details summary { margin-bottom: 30px }
 nav .site-nav section { line-height: 22px; margin-bottom: 40px;}
@@ -129,4 +131,7 @@ ul.nobull li {list-style-type: none}
 
 @media only screen and (max-width: 1100px) {
 	header, nav, main { padding: 20px;}
+	nav { float: none; }
+	nav { display: block; }
+	main + nav { display: none; }
 }

--- a/site/2018.html
+++ b/site/2018.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; 2018</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; 2018</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -73,108 +173,105 @@
 <p>Back to <a href='log.html' class='local'>log</a>.</p>
  
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Feb 27 09:49:11 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/2018.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/2019.html
+++ b/site/2019.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; 2019</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; 2019</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -191,108 +291,105 @@ In other news, we will also be hosting a livecoding ORCA workshop at <a href='ht
 <p>Back to <a href='log.html' class='local'>log</a>.</p>
  
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Tue Feb 28 16:38:19 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/2019.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/2020.html
+++ b/site/2020.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; 2020</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; 2020</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -217,108 +317,105 @@
 <p>Back to <a href='log.html' class='local'>log</a>.</p>
  
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Feb 27 09:50:07 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/2020.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/2021.html
+++ b/site/2021.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; 2021</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; 2021</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -284,108 +384,105 @@
 <p>Back to <a href='log.html' class='local'>log</a>.</p>
  
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Mar 15 08:34:35 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/2021.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/2022.html
+++ b/site/2022.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; 2022</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; 2022</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -305,108 +405,105 @@ https://git.sr.ht/~rabbits/uxn-playdate' target='_blank'>Playdate implementation
 <p>Back to <a href='log.html' class='local'>log</a>.</p>
  
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Mar 15 08:33:10 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/2022.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/2023.html
+++ b/site/2023.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; 2023</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; 2023</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -306,108 +406,105 @@ made the <a href="https://wiki.xxiivv.com/site/varvara_zine.html">Varvara Zine</
 <p>Back to <a href='log.html' class='local'>log</a>.</p>
  
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Mar 15 08:32:10 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/2023.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/2024.html
+++ b/site/2024.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; 2024</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; 2024</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -225,108 +325,105 @@
 
 <p><b>Book Club:</b> This month we are reading <i>The Haunting of Hill House</i> by Shirley Jackson.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Tue Nov 12 09:50:57 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Fri Nov 15 23:50:20 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/2024.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/6502_assembly.html
+++ b/site/6502_assembly.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; 6502 assembly</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; 6502 assembly</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -74,108 +174,105 @@ JMP MyFunction
 </pre>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Jun 28 20:03:17 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/6502_assembly.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/a_home_for_pino.html
+++ b/site/a_home_for_pino.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; a home for pino</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; a home for pino</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -196,108 +296,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Apr  5 10:04:30 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/a_home_for_pino.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/about_us.html
+++ b/site/about_us.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; about us</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; about us</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -147,108 +247,105 @@
 <p>This website has <b>no</b> tracking or analytics.</p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Tue Nov 12 09:45:32 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Fri Nov 15 23:50:20 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/about_us.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/abyc_wire_color_codes.html
+++ b/site/abyc_wire_color_codes.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; abyc wire color codes</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; abyc wire color codes</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -84,108 +184,105 @@
 <p>A wire that doesn't have the right color won't cause any electrical problems, the only downside is if the vessel is sold, a lack of color-coding may cause confusion that might lead to problems, say, using a red wire for a grounding wire instead of green.</p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Jan  4 16:14:04 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/abyc_wire_color_codes.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/ac_electrical_refit.html
+++ b/site/ac_electrical_refit.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; ac electrical refit</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; ac electrical refit</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -117,108 +217,105 @@
 </ul>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Apr 26 17:07:16 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/ac_electrical_refit.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/adelie.html
+++ b/site/adelie.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; adelie</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; adelie</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -404,108 +504,105 @@ WAIT 08
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Jul  3 09:51:30 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/adelie.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/ais.html
+++ b/site/ais.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; ais</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; ais</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -12,108 +112,105 @@
 
 <p>See our <a href='ais_installation.html' class='local'>ais installation</a>.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Jul 22 15:30:19 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/ais.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/ais_installation.html
+++ b/site/ais_installation.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; ais installation</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; ais installation</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -66,108 +166,105 @@ External Alarm/Buzzer Negative (-) to DC Negative / Ground</p>
 <img src='../media/content/boat_projects
 /ais_04.jpg' alt='vesper AIS and antenna splitterinstalled in a bulkhead' loading='lazy'/>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Apr 26 17:07:56 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/ais_installation.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/alcohol_stove.html
+++ b/site/alcohol_stove.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; alcohol stove</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; alcohol stove</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -58,108 +158,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Aug 26 12:14:22 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/alcohol_stove.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/an_island_to_oneself.html
+++ b/site/an_island_to_oneself.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; an island to oneself</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; an island to oneself</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -149,108 +249,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Apr 26 17:08:09 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/an_island_to_oneself.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/anchoring.html
+++ b/site/anchoring.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; anchoring</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; anchoring</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -27,108 +127,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Jul 24 13:04:41 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/anchoring.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/anchoring_setup.html
+++ b/site/anchoring_setup.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; anchoring setup</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; anchoring setup</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -65,108 +165,105 @@
 
 <img src='../media/content/knowledge/anchoring_gloves_old.jpg' alt='a very worn pair of anchoring gloves, full of holes and covered in rust and dried mud' loading='lazy'>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Jul 24 13:02:28 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/anchoring_setup.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/ascii.html
+++ b/site/ascii.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; ascii</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; ascii</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -281,108 +381,105 @@
     <tr><td>255</td><td>FF</td><td>ÿ</td><td>&amp;#255;</td><td>&amp;yuml;</td><td>LC y with diaeresis</td></tr>
 </table>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Feb 28 08:58:42 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/ascii.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/ballet_bay.html
+++ b/site/ballet_bay.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; ballet bay</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; ballet bay</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -21,108 +121,105 @@
 
 <p>Still, it is a good quiet spot, and a nice stopover if traveling up or down Malaspina Strait.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Oct 27 15:22:18 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/ballet_bay.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/barometer.html
+++ b/site/barometer.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; barometer</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; barometer</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -14,108 +114,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/barometer.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/batteries.html
+++ b/site/batteries.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; batteries</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; batteries</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -91,108 +191,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Jan  4 16:14:04 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/batteries.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/bc_north_coast_anchorages.html
+++ b/site/bc_north_coast_anchorages.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; bc north coast anchorages</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; bc north coast anchorages</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -38,108 +138,105 @@
 
 <p>We anchored here again on our west south for a few days, with NW winds in the forecast. Another boat was already at anchor in the little nook to the west, we anchored behind them in 40ft (52 at HW). There was a bit of swell coming from between the little islets, making the waters a bit lumpy, the wind was 10-20 out of the NW. We had scratchy VHF reception this time. That evening the wind started to blow down from the hills to the north, very strongly at times. In the day the wind came from the entrance to Captain Cove(second day a bit more from the head of the nook), but at night it rolled down from over the hill. We didn't sleep well that night because of the strong gusts. A 3rd sailboat had anchored at the SE end of the cove, and ended up moving to the NE in the evening because of the gusts, which were putting them stern to shore with a lot of open water ahead of them(not sure if they spent a good night there or not). During our stay here we spun around our anchor a lot, the wind at night was erratic, the wind had us point in 4 different directions(make sure you have room to swing).</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Aug 12 11:59:46 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/bc_north_coast_anchorages.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/beaufort_scale.html
+++ b/site/beaufort_scale.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; beaufort scale</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; beaufort scale</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -94,108 +194,105 @@
 
 <p>This is the scale that we use in our book <a href='busy_doing_nothing.html' class='local'>Busy Doing Nothing</a>.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/beaufort_scale.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/bed.html
+++ b/site/bed.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; bed</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; bed</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -44,108 +144,105 @@
 <p>Still loving this bed of ours. Best boat upgrade. One of the wooden slats has developed a crack, but we solidified it and it is fine.</p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Dec 29 14:28:51 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/bed.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/berg_bay.html
+++ b/site/berg_bay.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; berg bay</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; berg bay</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -30,108 +130,105 @@
 
 <p>The motor boat was anchored near the ranger cabin, we anchored far behind them in 65 feet. We only stayed in this beautiful place for one night. The wind was coming from the head of the bay when we arrived, then switched to the south later, but it died down in the evening. A south wind creates a bit of light chop in the bay, but it wasn't too bad. Tomorrow, we continued up Blake Channel to Wrangell.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Thu Jun 13 19:46:38 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/berg_bay.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/bikes.html
+++ b/site/bikes.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; bikes</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; bikes</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -42,108 +142,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Mar 18 20:16:42 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/bikes.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/bikes_on_a_boat.html
+++ b/site/bikes_on_a_boat.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; bikes on a boat</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; bikes on a boat</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -33,108 +133,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Nov 20 09:59:06 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/bikes_on_a_boat.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/board_games.html
+++ b/site/board_games.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; board games</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; board games</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -16,108 +116,105 @@
 </ul>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Dec  4 09:27:38 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/board_games.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/boat_projects.html
+++ b/site/boat_projects.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; boat projects</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; boat projects</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -49,108 +149,105 @@
 </ul>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Apr 26 19:59:35 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/boat_projects.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/boom_tent.html
+++ b/site/boom_tent.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; boom tent</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; boom tent</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -68,108 +168,105 @@
 <p>If we don't tie the aft ring to the backstay, it droops down and creates a deep V which we can use as a large water collector. There's a lot of surface, so if it's raining hard it can fill bins very fast.</p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat Aug 19 15:22:47 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/boom_tent.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/burgee.html
+++ b/site/burgee.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; burgee</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; burgee</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -47,108 +147,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat Feb 18 09:24:21 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/burgee.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/burgee_project.html
+++ b/site/burgee_project.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; burgee project</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; burgee project</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -37,108 +137,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Apr 26 17:11:49 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/burgee_project.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/busy_doing_nothing.html
+++ b/site/busy_doing_nothing.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; busy doing nothing</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; busy doing nothing</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -51,108 +151,105 @@
 <img src='../media/content/projects/busydoingnothing_06.png' alt='A screenshot of the desktop PDF version of Busy Doing Nothing' title='pdf version of Busy Doing Nothing' loading='lazy' />
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Nov 11 11:00:04 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Fri Nov 15 23:50:20 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/busy_doing_nothing.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/buying_a_sailboat.html
+++ b/site/buying_a_sailboat.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; buying a sailboat</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; buying a sailboat</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -93,108 +193,105 @@
 
 <p>Read about outfitting a vessel for sailing <a href='offshore.html' class='local'>offshore</a>.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Thu Nov  7 09:32:58 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Fri Nov 15 23:50:20 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/buying_a_sailboat.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/calling_for_help.html
+++ b/site/calling_for_help.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; calling for help</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; calling for help</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -61,108 +161,105 @@
 <q>PANPAN PANPAN PANPAN. Victoria Coastguard radio, Victoria Coastguard radio, Victoria Coastguard radio, this is Pino, Pino, Pino. We are a 10 m sloop with a white hull and red canvas, our position is 48°45'28.5"N 123°19'43.9"W, our prop is fouled and we need a tow to the nearest port. There are 2 people onboard. Over.</q>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sun Mar  3 20:39:07 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/calling_for_help.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/captain_what_is_this.html
+++ b/site/captain_what_is_this.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; captain what is this</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; captain what is this</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -81,108 +181,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Apr 26 17:12:24 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/captain_what_is_this.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/carbonation.html
+++ b/site/carbonation.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; carbonation</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; carbonation</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -19,108 +119,105 @@
 
 <p>See our <a href='diy_carbonation_system.html' class='local'>diy carbonation system</a>.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Mar 25 12:22:39 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/carbonation.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/cast_iron_cookware.html
+++ b/site/cast_iron_cookware.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; cast iron cookware</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; cast iron cookware</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -20,108 +120,105 @@
 <p>Highly acidic foods, like tomatoes, can break down the seasoning on cast iron, but it won't be an issue if the pan is well-seasoned.</p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/cast_iron_cookware.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/cathedral_grove.html
+++ b/site/cathedral_grove.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; cathedral grove</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; cathedral grove</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -43,108 +143,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Tue Apr 30 08:02:35 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/cathedral_grove.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/central_coast_anchorages.html
+++ b/site/central_coast_anchorages.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; central coast anchorages</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; central coast anchorages</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -57,108 +157,105 @@
 <p>On exit, you can take the Kipp Islet pass, but because we exited with some south winds so we took the north pass to get a bit of protection from the many islands and reefs along the shore (our rough path: 52°29.028'N, 128°46.219'W -> 52°29.124'N, 128°47.098'W -> 52°29.271'N, 128°47.422'W). It does get rough there, the waves are very messy once past the protection of the reefs. If you choose to do this, be very, very careful. We wanted to leave with south winds so we had to endure it, we motor sailed out just to be certain that we kept control of the boat, so as to not drift too far towards the shore. All was fine in the end, exiting from Higgins Passage with a north wind ought to be easy. No problems with VHF reception, no cell reception. </p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Aug 12 11:59:32 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/central_coast_anchorages.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/chainplates.html
+++ b/site/chainplates.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; chainplates</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; chainplates</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -100,108 +200,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Jun  3 12:28:44 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/chainplates.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/charging_electronics.html
+++ b/site/charging_electronics.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; charging electronics</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; charging electronics</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -115,108 +215,105 @@
 
 <img src='../media/content/boat_projects/charging_electronics10.jpg' alt='a fuse box' loading='lazy'>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Feb 28 10:42:07 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/charging_electronics.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/choosing_upholstery_fabric.html
+++ b/site/choosing_upholstery_fabric.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; choosing upholstery fabric</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; choosing upholstery fabric</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -22,108 +122,105 @@
 
 <p>If sensitive to dust mites choose a cover fabric that is <b>tightly-woven</b>.[<a href="https://www.jacionline.org/article/S0091-6749(06)01572-7/fulltext" target="_blank">Source</a>], which will keep dust mites from entering the foam. Latex does not keep dust mites out(it only keeps molds from growing inside it).</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Dec 29 12:15:14 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/choosing_upholstery_fabric.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/choosing_upholstery_foam.html
+++ b/site/choosing_upholstery_foam.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; choosing upholstery foam</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; choosing upholstery foam</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -8,108 +108,105 @@
 
 <p><b>Foam Material</b>. Commonly memory foam is made from polyurethane, but some people choose Latex(especially for bedding) because of its durability and its antimicrobial properties. Memory foam is cheap, but Latex is costly.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Dec 29 10:49:46 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/choosing_upholstery_foam.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/cleaning_products.html
+++ b/site/cleaning_products.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; cleaning products</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; cleaning products</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -75,108 +175,105 @@
 </table>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Mar 22 08:50:31 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/cleaning_products.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/coffee.html
+++ b/site/coffee.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; coffee</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; coffee</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -14,108 +114,105 @@
 
 <p>For a dark brown, use less water (1:1), for a lighter tone, dilute with more and re-coat until happy with the tint. For a dark coat, we like to add two layers with a paintbrush and let it dry in the sun. See the base for our <a href='woodstove_installation.html' class='local'>woodstove installation</a>, and the box for our <a href='dry_toilet.html' class='local'>dry toilet</a> for an example of this type of staining.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/coffee.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/communication.html
+++ b/site/communication.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; communication</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; communication</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -20,108 +120,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Jan  4 16:14:04 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/communication.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/computing_and_sustainability.html
+++ b/site/computing_and_sustainability.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; computing and sustainability</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; computing and sustainability</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -274,108 +374,105 @@
 
 <p>Thank you for reading.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Thu Nov  7 09:18:08 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/computing_and_sustainability.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/contribute.html
+++ b/site/contribute.html
@@ -1,111 +1,208 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; contribute</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; contribute</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
 <h1>contribute</h1><p>You can find the source files to all of our projects over on our <a href='https://git.sr.ht/~rabbits' target='_blank'>SourceHut</a> page.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/contribute.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/cook_islands.html
+++ b/site/cook_islands.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; cook islands</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; cook islands</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -23,108 +123,105 @@
 <img src='../media/content/travel/cookislands_03.jpg' title='A stop at the beach in Rarotonga' alt='A photograph of Rek standing on the beach, appearing pensive' loading='lazy'>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Feb 27 10:12:00 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/cook_islands.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/cooking.html
+++ b/site/cooking.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; cooking</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; cooking</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -490,108 +590,105 @@
 <p>We started Grimgrains to teach ourselves how to cook. This blog—which now doubles as a travel diary—helps measure our progress. It's also a way to share what we've learned.</p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Thu Nov  7 09:15:44 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Fri Nov 15 23:50:20 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/cooking.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/cost_of_simplicity.html
+++ b/site/cost_of_simplicity.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; cost of simplicity</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; cost of simplicity</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -8,108 +108,105 @@
 
 <p>A <a href='dry_toilet.html' class='local'>dry toilet</a> is as simple as it gets, with no hoses, thru-hulls or a holding tank, but the toilet itself occupies more space and we must carry medium to keep the solids covered. Boaters typically make use of shore facilities to pump out the sewage in their tanks, but with a dry toilet the task of emptying the bin becomes ours.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/cost_of_simplicity.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/costs.html
+++ b/site/costs.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; costs</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; costs</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -34,108 +134,105 @@
 
 <p><b>life rafts</b>. Re-packing a liferaft is very expensive, and varies depending on the model, and your location in the world.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sun Nov 19 13:03:51 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/costs.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/curtains.html
+++ b/site/curtains.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; curtains</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; curtains</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -59,108 +159,105 @@
 <img src='../media/content/boat_projects/curtains_07.jpg' loading='lazy'/>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Apr 26 17:16:09 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/curtains.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/data_storage.html
+++ b/site/data_storage.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; data storage</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; data storage</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -21,108 +121,105 @@
 <p>Keeping files on the cloud, on hard drives and hard copies gives our floating studio the redundancy required to ensure reliability.</p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat Jul  2 12:45:46 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/data_storage.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/dc_electrical_refit.html
+++ b/site/dc_electrical_refit.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; dc electrical refit</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; dc electrical refit</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -305,108 +405,105 @@ Electrical System Use and Maintenance</a>, David H. Pascoe, Marine surveyor.</li
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat Apr 27 11:55:45 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/dc_electrical_refit.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/decorations.html
+++ b/site/decorations.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; decorations</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; decorations</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -28,108 +128,105 @@
 
 <p>Every year, we also like to carve some <a href='halloween_pumpkins.html' class='local'>halloween pumpkins</a>.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sun Jan 22 09:20:50 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/decorations.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/diet.html
+++ b/site/diet.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; diet</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; diet</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -21,108 +121,105 @@
 <p>Appropriately planned plant-based diets are healthful, nutritionally adequate, and may provide health benefits in the prevention and treatment of certain diseases. See our detailed <a href='https://grimgrains.com/site/nutrition.html' target='_blank'>guide to plant-based nutrition</a>(GrimGrains).</p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Thu Nov  7 09:24:12 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Fri Nov 15 23:50:20 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/diet.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/distractions.html
+++ b/site/distractions.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; distractions</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; distractions</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -8,108 +108,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/distractions.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/ditch_bag.html
+++ b/site/ditch_bag.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; ditch bag</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; ditch bag</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -34,108 +134,105 @@
 </ul>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Nov  3 19:50:23 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/ditch_bag.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/diy_carbonation_system.html
+++ b/site/diy_carbonation_system.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; diy carbonation system</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; diy carbonation system</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -331,108 +431,105 @@
     <li><a href='https://www.kegerators.com/carbonation-table/' target='_blank'>Carbonation table</a></li>
 </ul>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Mar 25 19:48:57 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/diy_carbonation_system.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/documenting.html
+++ b/site/documenting.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; documenting</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; documenting</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -37,108 +137,105 @@
     <li><b>Gimp</b>(image optimization/resizing)</li>
 </ul>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat Apr 29 09:17:58 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/documenting.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/doldrumming.html
+++ b/site/doldrumming.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; doldrumming</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; doldrumming</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -124,108 +224,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Mar  4 08:59:16 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/doldrumming.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/donsol.html
+++ b/site/donsol.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; donsol</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; donsol</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -71,108 +171,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Oct 16 16:21:59 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/donsol.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/dotgrid.html
+++ b/site/dotgrid.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; dotgrid</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; dotgrid</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -204,108 +304,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Oct 16 16:26:40 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/dotgrid.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/drownspire.html
+++ b/site/drownspire.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; drownspire</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; drownspire</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -52,108 +152,105 @@
  <p>An Aliceffekt t-shirt.</p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/drownspire.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/dry_toilet.html
+++ b/site/dry_toilet.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; dry toilet</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; dry toilet</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -48,108 +148,105 @@
 <q>Some plants especially enjoy nitrogen, potassium and phosphorus found in urine: cabbage, beets, tomatoes and cucumbers. —Shit and Blossoms</q>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Feb 27 10:13:18 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/dry_toilet.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/dry_toilet_installation.html
+++ b/site/dry_toilet_installation.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; dry toilet installation</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; dry toilet installation</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -136,108 +236,105 @@
 <p><b><a id='aug2022'>2022.08.07</a>.</b> This is our first full summer with the dry toilet, so far so good. We have put a smaller recipient inside the larger one for the solids, to make it easier to take out and empty. The big bin has greater capacity, but emptying it is a hell of an endeavour. We have stopped adding liners to the bin. The liner helps when we have to empty the toilet into the trash, but is not so helpful for tossing overboard, or for bringing ashore to bury, or to dump into an outhouse. Cruising, we have found that many marine parks keep outhouses ashore. We emptied our toilet there while in Von Donop, and again in Grace Harbour. The one in Melanie Cove is gone, but the hole is still there. We have buried deposits, but lacking a shovel, making a hole is a long and tiresome affair. Next year, we'll get a shovel. The hole needs to be deep enough, and its depth depends on the amount that has to be buried. The larger the deposit the bigger the hole. We make holes away from trails, just to be safe.<br>The outhouses are another unexpected convenience. They're not chemical toilets, so the matter gets processed properly over time.</br>You might wonder if tossing a compostable bag overboard with its contents would be a good idea, it isn't. The bag doesn't decompose all that quickly in sea water, and is an eyesore to other boaters (it floats). We tried it once, but fished it back out right away... seeing how the bag and its contents weren't sinking. It is fine to dump the contents overboard (without the bag) if far away enough from shore.<br>The bin generally fills up after a week and a half, and we empty it then. It is small, easy to lift and carry ashore. The bin is a small plastic trash can, it has a rectangle shape with rounded corners. We prefer a bin that isn't circular because we don't want to risk aiming badly onto the side. Speaking of which, it is not easy to poo while on the high side when sailing. We had an accident when the boat was sailing to weather, very heeled, and the deposit ended up in the wrong compartment (oops). Ideally, we should ease off when someone needs to take a dump, or heave to. We are using a combination of wood shavings and coffee grounds still with good results. We keep the fan going for an hour or two after each deposit, then we turn it off.<br>We have been using our liquids tank a lot too, especially when in areas where there are a lot of swimmers (and where we too are swimming). We drilled a hole on top of the tank and added a fitting so we can feed a hose through to pump out the liquid. We thought we could fit a hose through the urine separator hose, but the curve is too aggressive. The people at the store told us we couldn't install a fitting onto the tank ourselves, because it is very difficult to get anything to bond to polyethylene. But, because we are stubborn, we tried it anyway. We bought some glue to bond difficult plastics, and it worked (we tried to get it budge, it didn't move). The glue is two-part, for serious bonding. The fitting has a screw-in top, easy to remove. We hadn't asked the people at the store to make a hole because we didn't know what would be most useful to us. Anyway, there won't be any hoses or anything pressure-sensitive attached to it. Using a handpump, we transfer the liquids into a smaller bottle which we can then dump overboard between anchorages. The pump is easy enough to wash, and the system remains simple.</p>
 <p><b><a id='Jul2023'>2023.07.16</a>.</b> This year we bought gardening tools at a thrift store, a little shovel and a mini rake, so we can bury our deposits properly. We have to pick our spot carefully, because a lot of places in BC don't have much topsoil, entire trees sit over slabs of rock. We still use the small plastic trash can to ferry the deposits to shore in the dinghy. It's a fine system. We don't really get bugs anymore, mostly because the tank is emptied every 7-9 days, and because we screen the windows and doors of the boat to keep flies out. We use wood shavings as a medium, along with old coffee grounds.</p> 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sun Jul 16 09:06:18 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/dry_toilet_installation.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/effect_of_combining_dissimilar_metals.html
+++ b/site/effect_of_combining_dissimilar_metals.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; effect of combining dissimilar metals</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; effect of combining dissimilar metals</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -11,108 +111,105 @@
 <img src="../media/content/knowledge/dissimilar_metals.jpg" loading="lazy"></a> 
 <cite>Author and source of above chart unknown</cite>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Nov 20 09:38:27 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/effect_of_combining_dissimilar_metals.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/electrical_refit.html
+++ b/site/electrical_refit.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; electrical refit</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; electrical refit</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -27,108 +127,105 @@
 
 <p>All outlets are above the waterline, near the cabin top. All wiring is tinned, with hermetically-sealed wire terminations.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Apr 26 17:15:33 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/electrical_refit.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/energy.html
+++ b/site/energy.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; energy</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; energy</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -58,108 +158,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat Jun 24 12:33:57 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/energy.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/engine_care.html
+++ b/site/engine_care.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; engine care</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; engine care</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -845,108 +945,105 @@
   </tr>
 </table>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Jul 22 17:04:57 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/engine_care.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/engine_rebuild.html
+++ b/site/engine_rebuild.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; engine rebuild</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; engine rebuild</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -95,108 +195,105 @@
 </ul>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Apr 26 17:16:26 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/engine_rebuild.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/fiji.html
+++ b/site/fiji.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; fiji</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; fiji</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -47,108 +147,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/fiji.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/first_aid_kit.html
+++ b/site/first_aid_kit.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; first aid kit</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; first aid kit</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -66,108 +166,105 @@
 <li>Emergency dental kit</li>
 </ul>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/first_aid_kit.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/food_storage.html
+++ b/site/food_storage.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; food storage</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; food storage</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -20,108 +120,105 @@
 
 <p>Weevil-prone items include flours, cereal, rice, quinoa, pasta, oats, barley, corn and wheat berries. See our notes on <a href='provisioning.html' class='local'>provisioning</a></p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/food_storage.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/forecast.html
+++ b/site/forecast.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; forecast</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; forecast</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -7,108 +107,105 @@
 <p>For information on storms brewing in the Pacific and Atlantic, as well as passage advice in the South Pacific, we enjoy reading <a href='https://metbob.wordpress.com/' target='_blank'>MetBob</a>.</p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/forecast.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/formalities.html
+++ b/site/formalities.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; formalities</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; formalities</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -17,108 +117,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/formalities.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/frances_bay.html
+++ b/site/frances_bay.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; frances bay</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; frances bay</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -16,108 +116,105 @@
 
 <p>Our anchor did not budge, and when we raised it the next day it hadn't gotten snagged on anything. It is not the best anchorage, for many reasons, but at least it's 7 NM from the <a href='yuculta_and_dent_rapids.html' class='local'>Yuculta and Dent Rapids</a>. We would have preferred to wake up later, but catching this neap tide was important to us, even if it meant rising before the sun. In <a href='twilight.html' class='local'>twilight</a>, everything was visible, even the little while fender floating over our anchor ahead.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Tue May 14 19:14:51 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/frances_bay.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/french_polynesia.html
+++ b/site/french_polynesia.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; french polynesia</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; french polynesia</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -29,108 +129,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/french_polynesia.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/frosty_bay.html
+++ b/site/frosty_bay.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; frosty bay</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; frosty bay</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -38,108 +138,105 @@
 
 <p>Frosty Bay is a lovely, quiet place, we're glad we stopped here. Our next stop, is <a href='berg_bay.html' class='local'>Berg Bay</a>.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Jun 12 18:50:41 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/frosty_bay.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/fuel_sensor.html
+++ b/site/fuel_sensor.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; fuel sensor</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; fuel sensor</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -45,108 +145,105 @@
 <img src='../media/content/boat_projects/fuel_gauge_06.jpg' alt='a gauge for a water tank installed on the wall' loading='lazy' />
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Apr 26 17:16:59 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/fuel_sensor.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/fury_cove.html
+++ b/site/fury_cove.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; fury cove</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; fury cove</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -25,108 +125,105 @@
 <p>We only stayed one night, because tomorrow some SE winds are forecasted, which ought to help us leap further north (we went to Codville Lagoon on King Island).</p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Tue May 28 18:57:10 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/fury_cove.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/gabriola.html
+++ b/site/gabriola.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; gabriola</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; gabriola</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -49,108 +149,105 @@
 
 <p>They resembled waves that have been turned to stone.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Jun 16 14:27:17 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/gabriola.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/galiano.html
+++ b/site/galiano.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; galiano</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; galiano</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -26,108 +126,105 @@
 
 <img src='../media/content/travel/galiano_05.jpg' loading='lazy'>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sun Mar 12 14:41:50 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/galiano.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/galley.html
+++ b/site/galley.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; galley</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; galley</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -9,108 +109,105 @@
 <p>We use our old ice box as a space for bulk containers of liquids, like big 5 L (1.3 US gal) bottles of olive oil, soy sauce, roasted sesame oil, apple cider vinegar, white vinegar etc.</p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Feb 19 08:50:17 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/galley.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/galley_plumbing.html
+++ b/site/galley_plumbing.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; galley plumbing</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; galley plumbing</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -74,108 +174,105 @@
 <img src='../media/content/boat_projects/galleyplumbing_sequence.jpg' alt='fynspray parts' loading='lazy'>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Apr 26 17:21:55 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/galley_plumbing.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/galley_refit.html
+++ b/site/galley_refit.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; galley refit</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; galley refit</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -27,108 +127,105 @@
 
 <p>Our galley design is far from perfect, we're not professionals, we are tinkerers and we like to iterate and learn. A galley like this is suited for people comfortable with adapting recipes, and who are interested in living without <a href='refrigeration.html' class='local'>refrigeration</a>.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Mar  1 08:42:28 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/galley_refit.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/galley_tools.html
+++ b/site/galley_tools.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; galley tools</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; galley tools</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -31,108 +131,105 @@
     <li>Spong Grinder No 20 (aka meat grinder)</li>
 </ul>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/galley_tools.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/gimballed_stove.html
+++ b/site/gimballed_stove.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; gimballed stove</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; gimballed stove</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -143,108 +243,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Tue Oct  8 11:36:26 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/gimballed_stove.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/goji_no_chaimu.html
+++ b/site/goji_no_chaimu.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; goji no chaimu</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; goji no chaimu</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -151,108 +251,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Apr 12 09:12:31 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/goji_no_chaimu.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/grace_harbour.html
+++ b/site/grace_harbour.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; grace harbour</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; grace harbour</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -45,108 +145,105 @@
 
 <p>Next stop, we go to <a href='melanie_cove.html' class='local'>Melanie Cove</a>.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sun Mar 12 15:24:01 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/grace_harbour.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/gravity_water_filter.html
+++ b/site/gravity_water_filter.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; gravity water filter</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; gravity water filter</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -61,108 +161,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Apr 26 17:22:14 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/gravity_water_filter.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/grib_files.html
+++ b/site/grib_files.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; grib files</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; grib files</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -21,108 +121,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sun Jul 28 12:37:30 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/grib_files.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/grimgrains.html
+++ b/site/grimgrains.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; grimgrains</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; grimgrains</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -8,108 +108,105 @@
 
 <p>We started Grimgrains to teach ourselves how to cook. This blog—which now doubles as a travel diary—helps measure our progress. It's also a way to share what we've learned.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/grimgrains.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/grinder.html
+++ b/site/grinder.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; grinder</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; grinder</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -30,108 +130,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/grinder.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/ground_tackle.html
+++ b/site/ground_tackle.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; ground tackle</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; ground tackle</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -14,108 +114,105 @@
 
 <p>Read about <a href='anchoring.html' class='local'>anchoring</a> etiquette.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Aug 26 12:27:26 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/ground_tackle.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/growing_food.html
+++ b/site/growing_food.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; growing food</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; growing food</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -29,108 +129,105 @@
 <img src='../media/content/cooking/leak-regrow.jpg' title='regrowing leek a few days later' alt='a photo showing leek being regrown in soil in a container with the stems now longer' loading='lazy'/>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Mar 15 10:14:11 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/growing_food.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/halloween_pumpkins.html
+++ b/site/halloween_pumpkins.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; halloween pumpkins</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; halloween pumpkins</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -39,108 +139,105 @@
 
 <img src='../media/content/inventory/pumpkin_seeds.jpg' title='roasted pumpkin seed snack' alt='a photo of a hand holding a jar of roasted and salted pumpkin seeds with their shell' loading='lazy'>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 19:53:50 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Fri Nov 15 23:50:20 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/halloween_pumpkins.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/hardware.html
+++ b/site/hardware.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; hardware</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; hardware</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -14,108 +114,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Jun 28 20:08:17 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/hardware.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/hathayim_marine_park.html
+++ b/site/hathayim_marine_park.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; hathayim marine park</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; hathayim marine park</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -140,108 +240,105 @@
 
 <p>We scanned their map to have a copy, but also thought that other sailors, or land-bound explorers, would enjoy seeing all of the existing trails on this part of Cortes Island.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Aug 30 19:33:02 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/hathayim_marine_park.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/hauling_out.html
+++ b/site/hauling_out.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; hauling out</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; hauling out</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -24,108 +124,105 @@
 
 <p>If your boat comes out of the water for a haul-out every year, a cheap alternative is to coat metal with zinc cream(penanten) or anhydrous lanolin(reported by others). Both products are available at the pharmacy. Note that neither last very long in the water.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Nov 20 09:43:31 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/hauling_out.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/headsail.html
+++ b/site/headsail.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; headsail</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; headsail</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -39,108 +139,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Apr 26 17:25:51 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/headsail.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/heating.html
+++ b/site/heating.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; heating</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; heating</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -44,108 +144,105 @@
 
 <p><b>Electric heaters:</b> We only use electric heaters when tied to a dock, we carry two aboard Pino. We chose a heater with many heat settings, which can draw less or more power. Many heaters only have settings that output at a constant 1000-1500W, but one that can be set more granularly, at 600W, 900W and 1500W is ideal. 600W is often enough to warm up the boat, and it's not as power demanding.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May 18 15:41:56 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/heating.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/hello_fujisan.html
+++ b/site/hello_fujisan.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; hello fujisan</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; hello fujisan</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -142,108 +242,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Apr  5 10:32:45 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/hello_fujisan.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/heriot_bay.html
+++ b/site/heriot_bay.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; heriot bay</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; heriot bay</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -49,108 +149,105 @@
 
 <p>Rebecca Spit is a good nearby option, but it's a busy anchorage, especially the spot on the NW tip of the spit (which offers the most north wind protection). Rebecca Spit is a marine park and there is a lovely trail all along the spit. Drew Harbour to the south seems like it would be great in a SE blow, but it is a longer trip to the Heriot Bay Inn dinghy dock (can't dock a dinghy at the nearby Taku Resort).</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Oct 27 15:22:32 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/heriot_bay.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/hexadecimal_table.html
+++ b/site/hexadecimal_table.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; hexadecimal table</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; hexadecimal table</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -1041,108 +1141,105 @@
 </table>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Feb 28 09:10:28 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/hexadecimal_table.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/hiversaires.html
+++ b/site/hiversaires.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; hiversaires</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; hiversaires</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -42,108 +142,105 @@
 <img src='../media/content/projects/hiversaires_03.jpg' loading='lazy' />
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Oct 16 16:24:12 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/hiversaires.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/home.html
+++ b/site/home.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; home</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; home</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -238,108 +338,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Feb 19 08:37:18 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/home.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/how_lpg_solenoids_work.html
+++ b/site/how_lpg_solenoids_work.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; how lpg solenoids work</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; how lpg solenoids work</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -28,108 +128,105 @@
 <p>When the current is turned off, the magnetic field collapses and the spring forces the plunger back into its original resting position.</p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Feb 28 12:41:33 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/how_lpg_solenoids_work.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/how_solenoids_work.html
+++ b/site/how_solenoids_work.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; how solenoids work</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; how solenoids work</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -17,108 +117,105 @@
 
 <p>With <b>N.C</b> valves, the flow of gas is obstructed by a metal plunger, with a spring forcing it into a closed position. The plunger and spring are contained within a large copper coil. When current is applied to a straight wire, the magnetic field moves in a circular pattern around the wire, but when the wire is shaped into a coil the magnetic field intensifies and is concentrated in the center. This magnetic field causes the metal plunger, attracted by the pull of magnetic field, to slide upward against the spring, opening the valve and allowing the gas to pass. When the current is turned off, the magnetic field collapses and the spring forces the plunger back into its original resting position.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Feb 28 08:44:38 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/how_solenoids_work.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/iggy.html
+++ b/site/iggy.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; iggy</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; iggy</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -35,108 +135,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Feb 27 10:28:16 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/iggy.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/index.html
+++ b/site/index.html
@@ -1,111 +1,208 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; index</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; index</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
 <h1>index</h1><ul class='col2 capital'><li><a href='2018.html'>2018</a></li><li><a href='2019.html'>2019</a></li><li><a href='2020.html'>2020</a></li><li><a href='2021.html'>2021</a></li><li><a href='2022.html'>2022</a></li><li><a href='2023.html'>2023</a></li><li><a href='2024.html'>2024</a></li><li><a href='6502_assembly.html'>6502 assembly</a></li><li><a href='a_home_for_pino.html'>a home for pino</a></li><li><a href='about_us.html'>about us</a></li><li><a href='abyc_wire_color_codes.html'>abyc wire color codes</a></li><li><a href='ac_electrical_refit.html'>ac electrical refit</a></li><li><a href='adelie.html'>adelie</a></li><li><a href='ais.html'>ais</a></li><li><a href='ais_installation.html'>ais installation</a></li><li><a href='alcohol_stove.html'>alcohol stove</a></li><li><a href='an_island_to_oneself.html'>an island to oneself</a></li><li><a href='anchoring.html'>anchoring</a></li><li><a href='anchoring_setup.html'>anchoring setup</a></li><li><a href='ascii.html'>ascii</a></li><li><a href='ballet_bay.html'>ballet bay</a></li><li><a href='barometer.html'>barometer</a></li><li><a href='batteries.html'>batteries</a></li><li><a href='bc_north_coast_anchorages.html'>bc north coast anchorages</a></li><li><a href='beaufort_scale.html'>beaufort scale</a></li><li><a href='bed.html'>bed</a></li><li><a href='berg_bay.html'>berg bay</a></li><li><a href='bikes.html'>bikes</a></li><li><a href='bikes_on_a_boat.html'>bikes on a boat</a></li><li><a href='board_games.html'>board games</a></li><li><a href='boat_projects.html'>boat projects</a></li><li><a href='boom_tent.html'>boom tent</a></li><li><a href='burgee.html'>burgee</a></li><li><a href='burgee_project.html'>burgee project</a></li><li><a href='busy_doing_nothing.html'>busy doing nothing</a></li><li><a href='buying_a_sailboat.html'>buying a sailboat</a></li><li><a href='calling_for_help.html'>calling for help</a></li><li><a href='captain_what_is_this.html'>captain what is this</a></li><li><a href='carbonation.html'>carbonation</a></li><li><a href='cast_iron_cookware.html'>cast iron cookware</a></li><li><a href='cathedral_grove.html'>cathedral grove</a></li><li><a href='central_coast_anchorages.html'>central coast anchorages</a></li><li><a href='chainplates.html'>chainplates</a></li><li><a href='charging_electronics.html'>charging electronics</a></li><li><a href='choosing_upholstery_fabric.html'>choosing upholstery fabric</a></li><li><a href='choosing_upholstery_foam.html'>choosing upholstery foam</a></li><li><a href='cleaning_products.html'>cleaning products</a></li><li><a href='coffee.html'>coffee</a></li><li><a href='communication.html'>communication</a></li><li><a href='computing_and_sustainability.html'>computing and sustainability</a></li><li><a href='contribute.html'>contribute</a></li><li><a href='cook_islands.html'>cook islands</a></li><li><a href='cooking.html'>cooking</a></li><li><a href='cost_of_simplicity.html'>cost of simplicity</a></li><li><a href='costs.html'>costs</a></li><li><a href='curtains.html'>curtains</a></li><li><a href='data_storage.html'>data storage</a></li><li><a href='dc_electrical_refit.html'>dc electrical refit</a></li><li><a href='decorations.html'>decorations</a></li><li><a href='diet.html'>diet</a></li><li><a href='distractions.html'>distractions</a></li><li><a href='ditch_bag.html'>ditch bag</a></li><li><a href='diy_carbonation_system.html'>diy carbonation system</a></li><li><a href='documenting.html'>documenting</a></li><li><a href='doldrumming.html'>doldrumming</a></li><li><a href='donsol.html'>donsol</a></li><li><a href='dotgrid.html'>dotgrid</a></li><li><a href='drownspire.html'>drownspire</a></li><li><a href='dry_toilet.html'>dry toilet</a></li><li><a href='dry_toilet_installation.html'>dry toilet installation</a></li><li><a href='effect_of_combining_dissimilar_metals.html'>effect of combining dissimilar metals</a></li><li><a href='electrical_refit.html'>electrical refit</a></li><li><a href='energy.html'>energy</a></li><li><a href='engine_care.html'>engine care</a></li><li><a href='engine_rebuild.html'>engine rebuild</a></li><li><a href='fiji.html'>fiji</a></li><li><a href='first_aid_kit.html'>first aid kit</a></li><li><a href='food_storage.html'>food storage</a></li><li><a href='forecast.html'>forecast</a></li><li><a href='formalities.html'>formalities</a></li><li><a href='frances_bay.html'>frances bay</a></li><li><a href='french_polynesia.html'>french polynesia</a></li><li><a href='frosty_bay.html'>frosty bay</a></li><li><a href='fuel_sensor.html'>fuel sensor</a></li><li><a href='fury_cove.html'>fury cove</a></li><li><a href='gabriola.html'>gabriola</a></li><li><a href='galiano.html'>galiano</a></li><li><a href='galley.html'>galley</a></li><li><a href='galley_plumbing.html'>galley plumbing</a></li><li><a href='galley_refit.html'>galley refit</a></li><li><a href='galley_tools.html'>galley tools</a></li><li><a href='gimballed_stove.html'>gimballed stove</a></li><li><a href='goji_no_chaimu.html'>goji no chaimu</a></li><li><a href='grace_harbour.html'>grace harbour</a></li><li><a href='gravity_water_filter.html'>gravity water filter</a></li><li><a href='grib_files.html'>grib files</a></li><li><a href='grimgrains.html'>grimgrains</a></li><li><a href='grinder.html'>grinder</a></li><li><a href='ground_tackle.html'>ground tackle</a></li><li><a href='growing_food.html'>growing food</a></li><li><a href='halloween_pumpkins.html'>halloween pumpkins</a></li><li><a href='hardware.html'>hardware</a></li><li><a href='hathayim_marine_park.html'>hathayim marine park</a></li><li><a href='hauling_out.html'>hauling out</a></li><li><a href='headsail.html'>headsail</a></li><li><a href='heating.html'>heating</a></li><li><a href='hello_fujisan.html'>hello fujisan</a></li><li><a href='heriot_bay.html'>heriot bay</a></li><li><a href='hexadecimal_table.html'>hexadecimal table</a></li><li><a href='hiversaires.html'>hiversaires</a></li><li><a href='home.html'>home</a></li><li><a href='how_lpg_solenoids_work.html'>how lpg solenoids work</a></li><li><a href='how_solenoids_work.html'>how solenoids work</a></li><li><a href='iggy.html'>iggy</a></li><li><a href='index.html'>index</a></li><li><a href='induction_cooking.html'>induction cooking</a></li><li><a href='installing_insulation.html'>installing insulation</a></li><li><a href='insulation.html'>insulation</a></li><li><a href='insulation_cooking.html'>insulation cooking</a></li><li><a href='insurance.html'>insurance</a></li><li><a href='internet.html'>internet</a></li><li><a href='internet_in_paradise.html'>internet in paradise</a></li><li><a href='japan.html'>japan</a></li><li><a href='jib_cars.html'>jib cars</a></li><li><a href='johnstone_strait_anchorages.html'>johnstone strait anchorages</a></li><li><a href='ketchikan.html'>ketchikan</a></li><li><a href='knots.html'>knots</a></li><li><a href='lactofermentation.html'>lactofermentation</a></li><li><a href='ladysmith.html'>ladysmith</a></li><li><a href='laundry.html'>laundry</a></li><li><a href='lazy_jacks.html'>lazy jacks</a></li><li><a href='left.html'>left</a></li><li><a href='left_electron.html'>left electron</a></li><li><a href='leleuvia.html'>leleuvia</a></li><li><a href='library.html'>library</a></li><li><a href='license.html'>license</a></li><li><a href='lifelines.html'>lifelines</a></li><li><a href='little_ninj.html'>little ninj</a></li><li><a href='liveaboard.html'>liveaboard</a></li><li><a href='living_aboard_in_winter.html'>living aboard in winter</a></li><li><a href='log.html'>log</a></li><li><a href='logbooks.html'>logbooks</a></li><li><a href='lost_logbook.html'>lost logbook</a></li><li><a href='lpg.html'>lpg</a></li><li><a href='lpg_fume_detection_system.html'>lpg fume detection system</a></li><li><a href='lpg_refit.html'>lpg refit</a></li><li><a href='mainsail.html'>mainsail</a></li><li><a href='maintenance_checklist.html'>maintenance checklist</a></li><li><a href='maintenance_cost.html'>maintenance cost</a></li><li><a href='making_saloon_cushions.html'>making saloon cushions</a></li><li><a href='making_seamed_box_cushions.html'>making seamed box cushions</a></li><li><a href='makogai.html'>makogai</a></li><li><a href='maple_bay.html'>maple bay</a></li><li><a href='marine_wire_termination.html'>marine wire termination</a></li><li><a href='markl.html'>markl</a></li><li><a href='marshall_islands.html'>marshall islands</a></li><li><a href='medical.html'>medical</a></li><li><a href='melanie_cove.html'>melanie cove</a></li><li><a href='meta.nav.html'>meta.nav</a></li><li><a href='metal_halyard_swaging.html'>metal halyard swaging</a></li><li><a href='mexico.html'>mexico</a></li><li><a href='mini_dodger.html'>mini dodger</a></li><li><a href='mission.html'>mission</a></li><li><a href='moisture_prevention_underliner.html'>moisture prevention underliner</a></li><li><a href='money.html'>money</a></li><li><a href='moorage.html'>moorage</a></li><li><a href='nasu.html'>nasu</a></li><li><a href='nasu_guide.html'>nasu guide</a></li><li><a href='navigation.html'>navigation</a></li><li><a href='new_zealand.html'>new zealand</a></li><li><a href='night_sailing.html'>night sailing</a></li><li><a href='niju.html'>niju</a></li><li><a href='ninj_blog.html'>ninj blog</a></li><li><a href='niue.html'>niue</a></li><li><a href='no_windlass.html'>no windlass</a></li><li><a href='noodle.html'>noodle</a></li><li><a href='north_pacific_logbook.html'>north pacific logbook</a></li><li><a href='north_pacific_ocean.html'>north pacific ocean</a></li><li><a href='nutrition.html'>nutrition</a></li><li><a href='oars.html'>oars</a></li><li><a href='octopus_islands.html'>octopus islands</a></li><li><a href='off_the_grid.html'>off the grid</a></li><li><a href='offshore.html'>offshore</a></li><li><a href='offshore_checklist.html'>offshore checklist</a></li><li><a href='ogasawara_cruising_guide.html'>ogasawara cruising guide</a></li><li><a href='open_pantry.html'>open pantry</a></li><li><a href='oquonie.html'>oquonie</a></li><li><a href='orca.html'>orca</a></li><li><a href='paradise.html'>paradise</a></li><li><a href='petersburg.html'>petersburg</a></li><li><a href='philosophy.html'>philosophy</a></li><li><a href='pino.html'>pino</a></li><li><a href='plantbased_diet_in_japan.html'>plantbased diet in japan</a></li><li><a href='port_mcneill.html'>port mcneill</a></li><li><a href='port_neville.html'>port neville</a></li><li><a href='power.html'>power</a></li><li><a href='press.html'>press</a></li><li><a href='pressure_cooker.html'>pressure cooker</a></li><li><a href='prince_rupert.html'>prince rupert</a></li><li><a href='princess_louisa_inlet.html'>princess louisa inlet</a></li><li><a href='privacy.html'>privacy</a></li><li><a href='productivity.html'>productivity</a></li><li><a href='projects_and_pain.html'>projects and pain</a></li><li><a href='propeller_maintenance.html'>propeller maintenance</a></li><li><a href='provisioning.html'>provisioning</a></li><li><a href='provisioning_in_japan.html'>provisioning in japan</a></li><li><a href='pull_request.html'>pull request</a></li><li><a href='rabbit_waves.html'>rabbit waves</a></li><li><a href='rabbits.html'>rabbits</a></li><li><a href='radio.html'>radio</a></li><li><a href='rain.html'>rain</a></li><li><a href='rainy_with_a_chance_of_mosquitoes.html'>rainy with a chance of mosquitoes</a></li><li><a href='ratz_harbor.html'>ratz harbor</a></li><li><a href='receiving_mail.html'>receiving mail</a></li><li><a href='reefing.html'>reefing</a></li><li><a href='refrigeration.html'>refrigeration</a></li><li><a href='refuge_cove.html'>refuge cove</a></li><li><a href='regulator.html'>regulator</a></li><li><a href='repair.html'>repair</a></li><li><a href='resources.html'>resources</a></li><li><a href='ronin.html'>ronin</a></li><li><a href='roscoe_bay.html'>roscoe bay</a></li><li><a href='ruth_island_cove.html'>ruth island cove</a></li><li><a href='safety_gear.html'>safety gear</a></li><li><a href='sailing.html'>sailing</a></li><li><a href='sailing_in_japan.html'>sailing in japan</a></li><li><a href='saloon_hatch.html'>saloon hatch</a></li><li><a href='satellite_phone.html'>satellite phone</a></li><li><a href='saturna.html'>saturna</a></li><li><a href='saving_fuel.html'>saving fuel</a></li><li><a href='schedule.html'>schedule</a></li><li><a href='seasickness.html'>seasickness</a></li><li><a href='setup.html'>setup</a></li><li><a href='sewing.html'>sewing</a></li><li><a href='shimoda.html'>shimoda</a></li><li><a href='shoal_bay.html'>shoal bay</a></li><li><a href='shore_power_cord_repair.html'>shore power cord repair</a></li><li><a href='shower.html'>shower</a></li><li><a href='sitka.html'>sitka</a></li><li><a href='sky_reading.html'>sky reading</a></li><li><a href='small_space.html'>small space</a></li><li><a href='smuggler_cove.html'>smuggler cove</a></li><li><a href='snubber.html'>snubber</a></li><li><a href='snug_cove.html'>snug cove</a></li><li><a href='software.html'>software</a></li><li><a href='sointula.html'>sointula</a></li><li><a href='solar.html'>solar</a></li><li><a href='solar_box_cooking.html'>solar box cooking</a></li><li><a href='solar_cooking.html'>solar cooking</a></li><li><a href='solar_cooking_experiment.html'>solar cooking experiment</a></li><li><a href='solar_evacuated_tube_cooking.html'>solar evacuated tube cooking</a></li><li><a href='solar_tips.html'>solar tips</a></li><li><a href='sprouting.html'>sprouting</a></li><li><a href='squalls.html'>squalls</a></li><li><a href='standing_rigging_replacement.html'>standing rigging replacement</a></li><li><a href='store.html'>store</a></li><li><a href='story.html'>story</a></li><li><a href='sturt_bay.html'>sturt bay</a></li><li><a href='sun_driers.html'>sun driers</a></li><li><a href='support.html'>support</a></li><li><a href='teapot.html'>teapot</a></li><li><a href='telegraph_cove.html'>telegraph cove</a></li><li><a href='tenedos_bay.html'>tenedos bay</a></li><li><a href='the_promise_of_pancakes.html'>the promise of pancakes</a></li><li><a href='the_rock_of_polynesia.html'>the rock of polynesia</a></li><li><a href='thousand_rooms.html'>thousand rooms</a></li><li><a href='thruhulls.html'>thruhulls</a></li><li><a href='tonga.html'>tonga</a></li><li><a href='toolbox.html'>toolbox</a></li><li><a href='tools_ecosystem.html'>tools ecosystem</a></li><li><a href='turnip.html'>turnip</a></li><li><a href='twilight.html'>twilight</a></li><li><a href='typhoons_and_mold.html'>typhoons and mold</a></li><li><a href='united_states.html'>united states</a></li><li><a href='upholstery.html'>upholstery</a></li><li><a href='us_se_alaska.html'>us se alaska</a></li><li><a href='us_west_coast.html'>us west coast</a></li><li><a href='uxn.html'>uxn</a></li><li><a href='uxn_design.html'>uxn design</a></li><li><a href='uxn_guide.html'>uxn guide</a></li><li><a href='verreciel.html'>verreciel</a></li><li><a href='victoria.html'>victoria</a></li><li><a href='victoria_to_sitka_logbook.html'>victoria to sitka logbook</a></li><li><a href='videos.html'>videos</a></li><li><a href='washing_dishes.html'>washing dishes</a></li><li><a href='washing_produce.html'>washing produce</a></li><li><a href='waste.html'>waste</a></li><li><a href='water.html'>water</a></li><li><a href='water_filtration.html'>water filtration</a></li><li><a href='water_storage.html'>water storage</a></li><li><a href='weather.html'>weather</a></li><li><a href='weathering_software_winter.html'>weathering software winter</a></li><li><a href='website.html'>website</a></li><li><a href='western_canada.html'>western canada</a></li><li><a href='wheel_to_tiller_conversion.html'>wheel to tiller conversion</a></li><li><a href='where.html'>where</a></li><li><a href='why_a_boat.html'>why a boat</a></li><li><a href='wiktopher.html'>wiktopher</a></li><li><a href='windlass_removal.html'>windlass removal</a></li><li><a href='window_replacement.html'>window replacement</a></li><li><a href='wood_upkeep.html'>wood upkeep</a></li><li><a href='woodstove.html'>woodstove</a></li><li><a href='woodstove_installation.html'>woodstove installation</a></li><li><a href='working_offgrid_efficiently.html'>working offgrid efficiently</a></li><li><a href='wrangell.html'>wrangell</a></li><li><a href='yuculta_and_dent_rapids.html'>yuculta and dent rapids</a></li></ul>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Nov 15 11:41:23 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Fri Nov 15 23:50:36 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/index.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/induction_cooking.html
+++ b/site/induction_cooking.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; induction cooking</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; induction cooking</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -14,108 +114,105 @@
 </div>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon May 13 16:34:16 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/induction_cooking.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/installing_insulation.html
+++ b/site/installing_insulation.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; installing insulation</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; installing insulation</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -117,108 +217,105 @@
 
 <img src='../media/content/boat_projects/clear_cockpit.jpg' loading='lazy'>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Dec 29 14:23:31 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/installing_insulation.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/insulation.html
+++ b/site/insulation.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; insulation</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; insulation</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -29,108 +129,105 @@
 
 <p>To see how we insulated part of Pino, see <a href='installing_insulation.html' class='local'>installing insulation</a>.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Dec 29 14:24:03 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/insulation.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/insulation_cooking.html
+++ b/site/insulation_cooking.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; insulation cooking</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; insulation cooking</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -14,108 +114,105 @@
 
 <p>It’s also possible to cook rice in a thermos, by simply pouring hot water over it and leaving it to slow cook.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/insulation_cooking.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/insurance.html
+++ b/site/insurance.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; insurance</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; insurance</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -26,108 +126,105 @@
 
 <p>A downside to insurance companies is that they are slowly pricing out small yacht owners. A machinist may not want to help a non-insured sailor with a small fix, because they can charge more to those with it. Small scale projects are not big money makers, and they are more likely to refuse them.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/insurance.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/internet.html
+++ b/site/internet.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; internet</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; internet</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -15,108 +115,105 @@
 <p>We research our destinations ahead of time to make sure we’ll have a reliable connection when we need it. This means we’ll be spending less time in secluded areas, and more time in city centers near a cell tower or WiFi signal. With some planning it is possible to have both paradise and connectivity, we found such a place in Huahine (see <a href='internet_in_paradise.html' class='local'>internet in paradise</a>) in <a href='french_polynesia.html' class='local'>French Polynesia</a>, and again in <a href='fiji.html' class='local'>Fiji</a>. Internet access will only get better as far-flung island nations gain purchasing power.</p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/internet.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/internet_in_paradise.html
+++ b/site/internet_in_paradise.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; internet in paradise</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; internet in paradise</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -101,108 +201,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Feb 27 10:05:07 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/internet_in_paradise.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/japan.html
+++ b/site/japan.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; japan</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; japan</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -41,108 +141,105 @@
 
 <img src='../media/content/travel/ogasawara_23.jpg' loading='lazy'>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/japan.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/jib_cars.html
+++ b/site/jib_cars.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; jib cars</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; jib cars</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -39,108 +139,105 @@
 <p>We broke the tip of our plastic fid recently, while trying to redo a splice for our chain to rope anchor rode. Perhaps it's time to seek out a sturdier design.</p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon May  8 09:42:50 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/jib_cars.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/johnstone_strait_anchorages.html
+++ b/site/johnstone_strait_anchorages.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; johnstone strait anchorages</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; johnstone strait anchorages</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -23,108 +123,105 @@
 <p>We had not planned on anchoring here(August 8th), we were aiming for Port Harvey, but our progress into Johnstone Strait from Sointula on Malcom Island was slow, too slow. The weather in Queen Charlotte Strait called for NW 15, diminishing to light overnight. The current was about to turn on us, so we headed for Boat Bay. We entered via a narrow pass north of the little island south of the bay, there were no kelp, but a fallen tree did extend some ways into the water. We anchored in 32 ft. There was some wind and wavelets, but nothing bad (might not be ideal in high W-NW winds or SE winds). The reefs bordering the bay offered some shelter. A cruiseship passed and it didn't disturb the waters too much-it may have been low tide at the time of its passing, the reefs offer more protection at low tide. We had a very quiet night here. The boat was enveloped in fog the next day, the wind rose to maybe 10-15 out of the NW, with little wavelets entering the anchorage, but again, it wasn't too bad, and we left for Forward Harbour shortly after anyway (around noon). In settled weather, this is a good stop, the holding was good. The shore has cabins and many tents, a small floating dock hosted a large inflatable speed boat, to take people back to the city, we imagined. We heard someone operating a chainsaw late in the evening, but otherwise it was very quiet.
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Aug 12 15:39:37 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/johnstone_strait_anchorages.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/ketchikan.html
+++ b/site/ketchikan.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; ketchikan</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; ketchikan</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -60,108 +160,105 @@
 
 <p>Many parts of this city are quite beautiful, but there are a lot of cars. The road to downtown is a noisy place, but walking through the houses on the elevated path does offer some respite. We will stay here for a few days, to wait for some weather to pass before moving to our next anchorage.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Tue Jun 18 09:46:55 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/ketchikan.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/knots.html
+++ b/site/knots.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; knots</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; knots</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -89,108 +189,105 @@
     <li><b>Marine use</b>: Used instead of ascenders to climb a mast, doesn't damage the rope it is secured to when sliding.</li>
 </ul>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Mar  4 09:01:02 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/knots.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/lactofermentation.html
+++ b/site/lactofermentation.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; lactofermentation</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; lactofermentation</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -29,108 +129,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Thu Nov  7 09:26:31 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Fri Nov 15 23:50:20 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/lactofermentation.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/ladysmith.html
+++ b/site/ladysmith.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; ladysmith</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; ladysmith</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -18,108 +118,105 @@
 
 <img src='../media/content/travel/ladysmith_02.jpg' alt='log company' loading='lazy'>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sun Mar 12 14:55:41 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/ladysmith.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/laundry.html
+++ b/site/laundry.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; laundry</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; laundry</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -14,108 +114,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Tue Jul  4 08:39:07 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/laundry.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/lazy_jacks.html
+++ b/site/lazy_jacks.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; lazy jacks</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; lazy jacks</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -32,108 +132,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Apr 26 17:23:35 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/lazy_jacks.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/left.html
+++ b/site/left.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; left</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; left</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -156,108 +256,105 @@
 <h2 id='pull_request'><a href='pull_request.html'>pull request</a></h2>
 <p>See the <a href='https://github.com/hundredrabbits/' target='_blank'>Github</a> and <a href='https://git.sr.ht/~rabbits/' target='_blank'>Sourcehut</a> repositories. Pull Requests are welcome, but please read our design <a href='philosophy.html' class='local'>philosophy</a> first. </p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Oct 16 16:26:22 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/left.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/left_electron.html
+++ b/site/left_electron.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; left electron</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; left electron</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -97,108 +197,105 @@
 </ul>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/left_electron.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/leleuvia.html
+++ b/site/leleuvia.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; leleuvia</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; leleuvia</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -61,108 +161,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/leleuvia.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/library.html
+++ b/site/library.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; library</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; library</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -224,108 +324,105 @@
 </ul>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat Jun 29 09:47:29 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/library.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/license.html
+++ b/site/license.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; license</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; license</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -9,108 +109,105 @@
 <p>You can find our more recent projects on <a href='https://git.sr.ht/~rabbits/' target='_blank'>Sourcehut</a>.</p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/license.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/lifelines.html
+++ b/site/lifelines.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; lifelines</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; lifelines</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -110,108 +210,105 @@ lashing more securely (HMPE is very slippery), while the HMPE is much stronger. 
 <p><b>Chafe?</b> Rigging Doctor wrote an excellent post on <a href="https://www.riggingdoctor.com/life-aboard/2015/10/16/how-much-chafe-is-too-much" target="_blank">How much chafe is too much</a>. The most common cause of failure is chafe through the stanchion holes, accelerated by burrs, which can be artifacts from manufacture or the result of wires rubbing over a long period of time. Ensuring that the stanchions holes are smooth is essential to a proper Amsteel lifeline installation. Since we've just installed ours, it'll be a long while before we can advise personally on this.</p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Feb 28 10:28:35 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/lifelines.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/little_ninj.html
+++ b/site/little_ninj.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; little ninj</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; little ninj</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -30,108 +130,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sun Mar  3 10:29:44 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/little_ninj.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/liveaboard.html
+++ b/site/liveaboard.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; liveaboard</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; liveaboard</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -202,108 +302,105 @@
 </ul>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Dec 29 14:21:06 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/liveaboard.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/living_aboard_in_winter.html
+++ b/site/living_aboard_in_winter.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; living aboard in winter</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; living aboard in winter</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -27,108 +127,105 @@
 <p>Consider getting a <a href='moisture_prevention_underliner.html' class='local'>moisture prevention underliner</a> to lay under the cushions so that the air can flow and inhibit the growth of mold and mildrew. It is good practice to lift the cushions to air them out even with a liner.</p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Dec 29 14:31:35 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/living_aboard_in_winter.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/log.html
+++ b/site/log.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; log</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; log</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -232,108 +332,105 @@
 <p>See log archives for <a href='2023.html' class='local'>2023</a>, <a href='2022.html' class='local'>2022</a>, <a href='2021.html' class='local'>2021</a>, <a href='2020.html' class='local'>2020</a>, <a href='2019.html' class='local'>2019</a>, and <a href='2018.html' class='local'>2018</a>.</p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Tue Nov 12 09:48:12 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Fri Nov 15 23:50:20 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/log.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/logbooks.html
+++ b/site/logbooks.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; logbooks</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; logbooks</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -12,108 +112,105 @@
 	<li><a href='victoria_to_sitka_logbook.html' class='local'>Victoria to Sitka logbook</a> - British Columbia(north and south) and Southeast Alaska, 2024</li>
 </ul>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Oct 18 19:03:33 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/logbooks.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/lost_logbook.html
+++ b/site/lost_logbook.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; lost logbook</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; lost logbook</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -299,108 +399,105 @@ Everything seems worse than it is when you are sleep deprived. It is harder to m
 
 <p>This marks the end of all entries from the lost logbook. Thank you for reading.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Feb 27 09:48:49 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/lost_logbook.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/lpg.html
+++ b/site/lpg.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; lpg</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; lpg</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -25,108 +125,105 @@
 <p><b>LPG flame sputtering?</b> Check the burner for debris, accumulations of carbon which might be clogging the burner. Other reasons include low propane pressure, faulty gas valves airflow obstruction, etc. Always check for clogging in the burners first, it happens a lot and it is an easy fix.</p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Aug 16 08:59:15 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/lpg.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/lpg_fume_detection_system.html
+++ b/site/lpg_fume_detection_system.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; lpg fume detection system</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; lpg fume detection system</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -85,108 +185,105 @@
 <p>We tested the solenoid and the control panel, all worked well! We are now able to control the solenoid from inside the boat again, yay!</p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Feb 28 10:59:02 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/lpg_fume_detection_system.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/lpg_refit.html
+++ b/site/lpg_refit.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; lpg refit</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; lpg refit</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -133,108 +233,105 @@
 
 <p>We sold our 3-burner LPG stove and scaled down to a single burner, see our <a href='gimballed_stove.html' class='local'>gimballed stove</a>. We also installed a new control panel and sniffer.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Tue Feb 27 10:29:52 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/lpg_refit.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/mainsail.html
+++ b/site/mainsail.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; mainsail</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; mainsail</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -55,108 +155,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Apr 26 17:26:14 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/mainsail.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/maintenance_checklist.html
+++ b/site/maintenance_checklist.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; maintenance checklist</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; maintenance checklist</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -47,108 +147,105 @@
     <li><b>EPIRB or PLB</b><br><i>Check registration is still valid, re-register with governing authority in your area if necessary. If information has changed(address, emergency contact information), apply changes to registration.</i></li>
 </ul>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Nov 20 10:39:13 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/maintenance_checklist.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/maintenance_cost.html
+++ b/site/maintenance_cost.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; maintenance cost</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; maintenance cost</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -28,108 +128,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sun Nov 19 11:24:56 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/maintenance_cost.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/making_saloon_cushions.html
+++ b/site/making_saloon_cushions.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; making saloon cushions</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; making saloon cushions</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -82,108 +182,105 @@
     <li><a href='making_seamed_box_cushions.html' class='local'>making seamed box cushions</a></li>
 </ul>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Feb 28 10:36:37 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/making_saloon_cushions.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/making_seamed_box_cushions.html
+++ b/site/making_seamed_box_cushions.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; making seamed box cushions</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; making seamed box cushions</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -200,108 +300,105 @@
     <li><a href='making_saloon_cushions.html' class='local'>making saloon cushions</a></li>
 </ul>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Feb 28 10:34:51 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/making_seamed_box_cushions.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/makogai.html
+++ b/site/makogai.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; makogai</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; makogai</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -114,108 +214,105 @@
 
 <p><b>Instructions</b>: <br> Full recipe calls for 1.75L bottle of vodka plus another bottle large enough to hold the infusion, and eventually the entire 1.75L of gin. Crush the coriander, zest the lemons or limes. Add all ingredients except cardamom pods to half of the 1.75L of vodka. Add Cardamom pods, crushed, a day later. Let sit for 6 more days. Strain through a coffee filter, or other material to remove solids. Add remaining vodka, the gin won’t be clear, but it tastes fine! You can also do this to cheaper gin, to make it into super tasty gin!</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/makogai.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/maple_bay.html
+++ b/site/maple_bay.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; maple bay</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; maple bay</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -24,108 +124,105 @@
 
 <img src='../media/content/travel/maple_bay_04.jpg' loading='lazy'>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Jun 14 10:57:38 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/maple_bay.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/marine_wire_termination.html
+++ b/site/marine_wire_termination.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; marine wire termination</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; marine wire termination</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -45,108 +145,105 @@
 
 <img src='../media/content/boat_projects/wiring_11.jpg' alt='some wires running through a gang terminal' loading='lazy' />
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Jan  9 16:50:03 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/marine_wire_termination.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/markl.html
+++ b/site/markl.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; markl</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; markl</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -32,108 +132,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Feb 27 10:26:30 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/markl.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/marshall_islands.html
+++ b/site/marshall_islands.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; marshall islands</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; marshall islands</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -21,108 +121,105 @@
 <img src='../media/content/travel/marshallislands_04.jpg' loading='lazy'>
 <img src='../media/content/travel/marshallislands_05.jpg' loading='lazy'>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Tue Oct 24 18:30:50 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/marshall_islands.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/medical.html
+++ b/site/medical.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; medical</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; medical</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -168,108 +268,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Tue Aug 27 15:20:08 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/medical.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/melanie_cove.html
+++ b/site/melanie_cove.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; melanie cove</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; melanie cove</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -71,108 +171,105 @@
 <p>We didn't go walk on the trail on the north shore of Melanie Cove this time around, because one morning we heard people screaming, and saw them running along the edge of the cliff where our boat, and many others, were stern-tied. They had been stung by wasps. Because Devine had a recent bad encounter with a wasp and that their reaction to the sting was bad, we decided not to chance it. We instead went walking on the trail on the south west side, leading to Unwin Lake, but met a couple and their kids who told us that they too had stepped onto a yellowjacket nest and had gotten bit. We wore pants that day, and proceeded carefully (we didn't see the nest). We stayed for 8 days.</p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri May 10 17:53:28 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/melanie_cove.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/meta.nav.html
+++ b/site/meta.nav.html
@@ -1,214 +1,308 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; meta.nav</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; meta.nav</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
-<h1>meta.nav</h1><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+<h1>meta.nav</h1><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Oct 18 19:00:39 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Fri Nov 15 23:50:20 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/meta.nav.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/metal_halyard_swaging.html
+++ b/site/metal_halyard_swaging.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; metal halyard swaging</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; metal halyard swaging</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -39,108 +139,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Apr 26 17:22:40 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/metal_halyard_swaging.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/mexico.html
+++ b/site/mexico.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; mexico</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; mexico</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -25,108 +125,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Jan  4 16:14:04 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/mexico.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/mini_dodger.html
+++ b/site/mini_dodger.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; mini dodger</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; mini dodger</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -131,108 +231,105 @@
 
 <p>Also, on our sail to <a href='us_se_alaska.html' class='local'>us se alaska</a> this summer, one of the aluminum tracks broke off. The other track is still on. We'll probably have to fix it mechanically with screws... we both hate that idea, but glassing wasn't enough.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Oct 25 14:15:47 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/mini_dodger.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/mission.html
+++ b/site/mission.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; mission</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; mission</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -40,108 +140,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sun Apr 16 12:09:35 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/mission.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/moisture_prevention_underliner.html
+++ b/site/moisture_prevention_underliner.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; moisture prevention underliner</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; moisture prevention underliner</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -39,108 +139,105 @@
 
 <p>We have found that the airing material with an organized mesh collapses more readily than those that don't, the. We bought a sheet from two different sources to test both designs. The design with the organized mesh could still help to keep cushions dry, but may not be as useful when placed under a lot of weight. We'll let you know how both have performed in the spring.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Feb 28 10:39:08 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/moisture_prevention_underliner.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/money.html
+++ b/site/money.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; money</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; money</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -6,108 +106,105 @@
 
 <p>Better make sure that your credit card will not be blocked when used in foreign countries, and that it will expire at a location that will allow for you to receive a new one.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/money.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/moorage.html
+++ b/site/moorage.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; moorage</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; moorage</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -12,108 +112,105 @@
 
 <p>Living aboard your boat will cause wear from regular use of the space. If staying at a marina in your home country for long periods, paying for <b>liveaboard fees</b> (up to $150 extra per month) is necessary. If staying in a marina in a foreign country, liveaboard fees are often waived. Some marinas charge for electricity and water, be sure to take that into account, especially if you have plans to winter there and that your heating is electric. In winter, marinas charge less than in the high season. A marina that charges 900$ per month in the summer can charge 500$ in the winter.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/moorage.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/nasu.html
+++ b/site/nasu.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; nasu</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; nasu</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -234,108 +334,105 @@ Meet <b>Nasubit</b>, the mascot for Nasu. Nasubit is there to talk about updates
 
 <img src='../media/content/projects/nasu_02.jpg' loading='lazy' />
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Oct 16 16:25:25 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/nasu.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/nasu_guide.html
+++ b/site/nasu_guide.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; nasu guide</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; nasu guide</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -216,108 +316,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Jan  4 16:14:04 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/nasu_guide.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/navigation.html
+++ b/site/navigation.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; navigation</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; navigation</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -6,108 +106,105 @@
 <p>The chartplotter was a donation from our friends on <a href='https://dakotaventures.home.blog/' target='_blank'>SY Dakota</a> (they upgraded theirs and gave us their old one in 2022). For now, it carries all of the maps for <a href='western_canada.html' class='local'>western canada</a>.</p>
 <p>We carry a sextant aboard, and both of us are learning to use it. Depending on GPS isn't ideal, and learning to navigate without it might save your life.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sun Sep  8 18:07:30 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/navigation.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/new_zealand.html
+++ b/site/new_zealand.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; new zealand</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; new zealand</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -26,108 +126,105 @@
 <img src='../media/content/travel/nz_07.jpg' loading='lazy'>
 <img src='../media/content/travel/nz_08.jpg' loading='lazy'>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/new_zealand.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/night_sailing.html
+++ b/site/night_sailing.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; night sailing</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; night sailing</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -14,108 +114,105 @@
 <p>Since we started sailing, we have stuck to the same pattern for night shifts. One sleeps between 1900 and 2100, then sails between 2100 and 2400, then goes back to sleep from 2400 until 0300, and then goes back to the tiller between 0300 and 0600. 3 hours on, and 3 hours off. Some sailors prefer longer shifts, doing 4-5 hours at a time. We prefer shorter shifts, because we get tired easy, and 3 hours, when tired, feels unending. If ever we need more sleep, we take short naps in the day.</p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/night_sailing.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/niju.html
+++ b/site/niju.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; niju</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; niju</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -34,108 +134,105 @@
 <img src='../media/content/projects/niju_02.jpg' loading='lazy' /><img src='../media/content/projects/niju_03.jpg' loading='lazy' />
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Oct 16 16:24:29 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/niju.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/ninj_blog.html
+++ b/site/ninj_blog.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; ninj blog</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; ninj blog</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -42,108 +142,105 @@
 </table>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Mar  4 10:11:06 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/ninj_blog.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/niue.html
+++ b/site/niue.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; niue</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; niue</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -25,108 +125,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/niue.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/no_windlass.html
+++ b/site/no_windlass.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; no windlass</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; no windlass</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -40,108 +140,105 @@
 
 <img src='../media/content/knowledge/anchoring_gloves_old.jpg' alt='a very worn pair of anchoring gloves, full of holes and covered in rust and dried mud' loading='lazy'>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Oct 16 19:02:33 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/no_windlass.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/noodle.html
+++ b/site/noodle.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; noodle</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; noodle</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -204,108 +304,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Oct 16 16:26:02 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/noodle.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/north_pacific_logbook.html
+++ b/site/north_pacific_logbook.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; north pacific logbook</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; north pacific logbook</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -1517,108 +1617,105 @@
 </tr>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Tue Apr 30 08:03:01 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/north_pacific_logbook.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/north_pacific_ocean.html
+++ b/site/north_pacific_ocean.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; north pacific ocean</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; north pacific ocean</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -19,108 +119,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Tue Apr 30 09:47:33 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/north_pacific_ocean.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/nutrition.html
+++ b/site/nutrition.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; nutrition</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; nutrition</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -24,108 +124,105 @@
 <p><a href='https://grimgrains.com/site/nutrition.html' target='_blank'>Read more</a> about plant based nutrition.</p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/nutrition.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/oars.html
+++ b/site/oars.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; oars</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; oars</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -72,108 +172,105 @@
 
 <p>We epoxied a thin rope onto the part of the oar as a stopper. We also made a rope loop to further help keep the oars from sliding. We have yet to test these, but we think it will help a lot!</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Apr 26 17:25:35 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/oars.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/octopus_islands.html
+++ b/site/octopus_islands.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; octopus islands</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; octopus islands</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -117,108 +217,105 @@
 
 <p>We also returned to this anchorage because we knew our friends Rik & Kay were coming, and they'd anchor in Squirrel Cove. This anchorage is a short 30 minute hike from <a href='hathayim_marine_park.html' class='local'>hathayim marine park</a>.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Tue Feb 20 10:11:40 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/octopus_islands.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/off_the_grid.html
+++ b/site/off_the_grid.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; off the grid</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; off the grid</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -512,108 +612,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Mar 18 10:32:09 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/off_the_grid.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/offshore.html
+++ b/site/offshore.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; offshore</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; offshore</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -20,108 +120,105 @@
 
 <p>Before every long passage, we do a thorough check of all equipment on board, this means looking at the stitching on the sails, testing the electronics, checking the running and standing rigging etc. For the first time, have someone with you to help, you can also hire professionals to inspect your boat. For example, we hired a rigger to inspect Pino's standing rigging when we were planning to go offshore for the first time. We asked him a lot of questions, watched how he did things etc.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/offshore.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/offshore_checklist.html
+++ b/site/offshore_checklist.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; offshore checklist</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; offshore checklist</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -152,108 +252,105 @@ approx. 2m of 12mm hollow-core rope, soldering iron & solder, self-amalgamating 
 
 <p>Read up on their <a href='https://www.muktuk.de/2023/03/02/achtunddreissig-wochen-auf-see/' target='_blank'>antenna adventures</a>. They arrived safely in Okinawa JP on March 20th 2023.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Nov  3 19:49:37 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/offshore_checklist.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/ogasawara_cruising_guide.html
+++ b/site/ogasawara_cruising_guide.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; ogasawara cruising guide</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; ogasawara cruising guide</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -207,108 +307,105 @@ The bill please!
 
 <p>We also wrote a guide to <a href='provisioning_in_japan.html' class='local'>provisioning in Japan</a>, <a href='sailing_in_japan.html' class='local'>sailing in japan</a>, and wrote a more personal about our visit to Chichijima in the entry <a href='goji_no_chaimu.html' class='local'>Goji no chaimu</a>.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Apr  5 11:16:34 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/ogasawara_cruising_guide.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/open_pantry.html
+++ b/site/open_pantry.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; open pantry</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; open pantry</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -54,108 +154,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Feb 28 10:31:56 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/open_pantry.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/oquonie.html
+++ b/site/oquonie.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; oquonie</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; oquonie</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -54,108 +154,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Oct 16 16:20:22 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/oquonie.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/orca.html
+++ b/site/orca.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; orca</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; orca</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -326,108 +426,105 @@ CM1.    Will output lowercase C.
 <p>See the <a href='https://github.com/hundredrabbits/' target='_blank'>Github</a> and <a href='https://git.sr.ht/~rabbits/' target='_blank'>Sourcehut</a> repositories. Pull Requests are welcome, but please read our design <a href='philosophy.html' class='local'>philosophy</a> first. </p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Oct 16 14:41:09 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/orca.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/paradise.html
+++ b/site/paradise.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; paradise</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; paradise</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -12,108 +112,105 @@
 <a class='button' href='https://hundredrabbits.itch.io/paradise/purchase?popup=1'>Buy Paradise | $1.00 USD</a>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Oct 16 16:24:49 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/paradise.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/petersburg.html
+++ b/site/petersburg.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; petersburg</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; petersburg</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -33,108 +133,105 @@
 
 <p>The town has Norwegian roots, which explains some of the street names, Norway flags, and decorations around town, but in the 1900's, prior to Peter Buschmann and the arrival of other Scandinavian immigrants, the north of Mitkof Island was already long occupied by Tlingit people.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Jun 17 08:52:29 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/petersburg.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/philosophy.html
+++ b/site/philosophy.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; philosophy</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; philosophy</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -23,108 +123,105 @@
 <img src='../media/interface/nonazi.png' style='width:100px' class='mono'/>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/philosophy.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/pino.html
+++ b/site/pino.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; pino</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; pino</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -16,108 +116,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Thu Sep 14 17:27:23 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/pino.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/plantbased_diet_in_japan.html
+++ b/site/plantbased_diet_in_japan.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; plantbased diet in japan</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; plantbased diet in japan</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -227,108 +327,105 @@ Niku wo tabemassen.
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat Apr  6 09:47:21 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/plantbased_diet_in_japan.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/port_mcneill.html
+++ b/site/port_mcneill.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; port mcneill</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; port mcneill</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -46,108 +146,105 @@
 
 <img src='../media/content/travel/pino_sails_moonshine.jpg' alt='pino sailing in Queen Charlotte strait, after leaving Port Mcneill' loading='lazy'>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Jun  3 20:07:03 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/port_mcneill.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/port_neville.html
+++ b/site/port_neville.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; port neville</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; port neville</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -34,108 +134,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Jun  3 12:25:10 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/port_neville.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/power.html
+++ b/site/power.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; power</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; power</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -24,108 +124,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Thu Nov  7 09:21:50 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Fri Nov 15 23:50:20 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/power.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/press.html
+++ b/site/press.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; press</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; press</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -144,108 +244,105 @@
 </ul>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Thu Nov  7 09:43:16 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Fri Nov 15 23:50:20 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/press.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/pressure_cooker.html
+++ b/site/pressure_cooker.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; pressure cooker</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; pressure cooker</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -11,108 +111,105 @@
 <p>Pressure cookers are generally quite big, and double as a big pot(we use ours to boil corn).</p> 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Jan  4 16:14:04 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/pressure_cooker.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/prince_rupert.html
+++ b/site/prince_rupert.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; prince rupert</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; prince rupert</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -49,108 +149,105 @@
 
 <p><b>Checking back into Canada</b>. When docked in port, at either Cow Bay Marina or the Yacht Club(apparently those are the only approved marinas for entry into the country), we had to call 1-888-226-7277 to report our arrival. I'm not sure why docking is necessary, but they insisted on it, even if they didn't board us. On the phone they took down our passport information, boat registration, where we'd been, how long, if we had produce(they don't want plants/produce not from a grocery store) ect, then they gave us a clearance number, and that was it.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Oct 28 18:55:40 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/prince_rupert.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/princess_louisa_inlet.html
+++ b/site/princess_louisa_inlet.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; princess louisa inlet</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; princess louisa inlet</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -242,108 +342,105 @@
 
 <p>Now, it's time for a rest.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Apr  5 08:51:47 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/princess_louisa_inlet.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/privacy.html
+++ b/site/privacy.html
@@ -1,112 +1,209 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; privacy</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; privacy</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
 <h1>privacy</h1><p>There is no privacy on a small boat. It's something you must prepare for. If you have plans to travel for extended periods of time with another person, you must be compatible, you must discuss problems when they arise and express concerns right away.</p>
 <p>The combined space, below and atop deck, is bigger than it seems. If you are near land, there is always the option of going for a walk.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/privacy.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/productivity.html
+++ b/site/productivity.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; productivity</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; productivity</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -13,108 +113,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/productivity.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/projects_and_pain.html
+++ b/site/projects_and_pain.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; projects and pain</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; projects and pain</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -137,108 +237,105 @@
 <p>I'll close this post, by thanking all in NZ who helped us out, for repairs, general advice - whatever. Time and knowledge is precious, we thank you: <b>Herbert & Asma</b> (s/y Maya), <b>Jim & Linda</b> (S/Y Bright moments), <b>Pauline and Antoine</b> (s/y Magellan), <b>Becky Jeffries</b> (uksails) & <b>Daniel</b> (c-spar).</p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Feb 27 10:20:05 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/projects_and_pain.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/propeller_maintenance.html
+++ b/site/propeller_maintenance.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; propeller maintenance</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; propeller maintenance</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -123,108 +223,105 @@
 
 <p>When Pino splashed back in the water, the seal appeared to not leak, as was designed (YAY). A pss shaft seal ought to have its bellow replaced every 6-7 years... but we may revisit this again when we actually replace the cutless bearing. It'll then be necessary to buy some extra set screws for the SS rotor (since they are single use) and that it'll be necessary to remove them to pull the shaft. The nightmare isn't over, just... delayed.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Mar  8 15:57:11 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/propeller_maintenance.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/provisioning.html
+++ b/site/provisioning.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; provisioning</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; provisioning</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -27,108 +127,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Thu Mar 28 10:27:42 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/provisioning.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/provisioning_in_japan.html
+++ b/site/provisioning_in_japan.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; provisioning in japan</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; provisioning in japan</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -837,108 +937,105 @@ No, I'm ok without a bag.
 </ul>
 </p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sun Apr  7 11:00:44 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/provisioning_in_japan.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/pull_request.html
+++ b/site/pull_request.html
@@ -1,112 +1,209 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; pull request</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; pull request</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
 <h1>pull request</h1>
 <p>See the <a href='https://github.com/hundredrabbits/' target='_blank'>Github</a> and <a href='https://git.sr.ht/~rabbits/' target='_blank'>Sourcehut</a> repositories. Pull Requests are welcome, but please read our design <a href='philosophy.html' class='local'>philosophy</a> first. </p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/pull_request.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/rabbit_waves.html
+++ b/site/rabbit_waves.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; rabbit waves</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; rabbit waves</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -21,108 +121,105 @@
 <img src='../media/content/projects/rabbitwaves_03.jpg' alt='a sketchbook page showing art done with ink and coloring pencils, on one page the phonetic alphabet is visible' loading='lazy' />
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Thu Oct 17 10:08:54 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/rabbit_waves.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/rabbits.html
+++ b/site/rabbits.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; rabbits</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; rabbits</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -6,108 +106,105 @@
 
 <p><a href='https://kokorobot.ca' target='_blank'>Rek</a>(they/them/iel) is a writer, illustrator and cartoonist, <a href='https://xxiivv.com' target='_blank'>Devine</a>(they) is a programmer, artist and musician, <a href='little_ninj.html' class='local'>Little Ninj</a> is our mascot and overlord.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Tue Nov 12 09:55:00 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Fri Nov 15 23:50:20 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/rabbits.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/radio.html
+++ b/site/radio.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; radio</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; radio</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -11,108 +111,105 @@
 <p>We sometimes use the two transceiver two-way radios to talk to each other from shore-to-shore, an <b>Amateur Radio License</b> is required to broadcast with this type of radio in Canada. A license ensures that new users are aware of the existing regulations and don't broadcast on reserved frequencies.</p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Jan  4 16:14:04 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/radio.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/rain.html
+++ b/site/rain.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; rain</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; rain</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -26,108 +126,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat Aug 19 15:16:49 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/rain.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/rainy_with_a_chance_of_mosquitoes.html
+++ b/site/rainy_with_a_chance_of_mosquitoes.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; rainy with a chance of mosquitoes</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; rainy with a chance of mosquitoes</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -99,108 +199,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Apr 26 17:21:21 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/rainy_with_a_chance_of_mosquitoes.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/ratz_harbor.html
+++ b/site/ratz_harbor.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; ratz harbor</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; ratz harbor</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -30,108 +130,105 @@
 
 <p>Ratz Harbor might be a fine place to stop if you understand the weather of the area well, but if you're new to the area, like us, and that the weather isn't completely calm, skip it and save yourself some pain. The holding was good in the southern portion of the bay, even if the water is deep. We are glad we decided to leave, because the wind stayed in the north all night, and again the same day(even if the forecast called for south winds on that day too...).</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Thu Nov 14 10:04:25 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Fri Nov 15 23:50:20 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/ratz_harbor.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/receiving_mail.html
+++ b/site/receiving_mail.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; receiving mail</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; receiving mail</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -18,108 +118,105 @@
 <p><b>A permanent business address</b>. For those who liveaboard near a city, it is possible to rent a virtual office to receive mail. This option is good for those who work from their boat and require a permanent address for their business. For example, our friends on the sailboat(SV Bloom) use the Paramount Executive Center in Victoria B.C. as a permanent address for their business(it acts as a virtual office) and to receive mail, but it's pricey($55/mo). They also recommended Datatech Business Solutions(again, in Victoria B.C), which is supposed to be a bit cheaper, but we have not checked.</p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sun Mar 17 18:27:34 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/receiving_mail.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/reefing.html
+++ b/site/reefing.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; reefing</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; reefing</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -12,108 +112,105 @@
 
 <p>Before we start our night shifts, we usually reef the <a href='mainsail.html' class='local'>mainsail</a>. A smaller sail will slow us down, but our main concern is safety. The rule is that if the wind rises enough to have us question whether we should reef or not, we do it. Another important rule, is to never reef at night. Everything is harder to do in the dark. We have done it before, with success, but the issue is that it means waking up your partner, robbing them of their precious sleep. Can't we reef a sail alone? Yes, we could, but that would break another rule: never wander on deck in the dark alone, even with a tether. Therefore, we plan to always do our last manoeuvres of the day while there is still some light out, at the cost of speed.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/reefing.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/refrigeration.html
+++ b/site/refrigeration.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; refrigeration</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; refrigeration</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -45,108 +145,105 @@
 <p>Read <a href='https://www.ediblegeography.com/the-anti-fridge/' target='_blank'>the anti-fridge</a> and <a href='http://www.savefoodfromthefridge.com/' target='_blank'>Save Food From the Fridge</a>.</p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Thu Nov  7 09:24:52 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Fri Nov 15 23:50:20 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/refrigeration.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/refuge_cove.html
+++ b/site/refuge_cove.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; refuge cove</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; refuge cove</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -14,108 +114,105 @@
 
 <p>A floating barge not too far from the Refuge Cove dock accepts garbage for a free (we haven't done it, we keep our garbage all summer).</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri May 10 18:11:14 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/refuge_cove.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/regulator.html
+++ b/site/regulator.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; regulator</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; regulator</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -177,108 +277,105 @@
 <p>We used our little DIY regulator a lot this summer when sailing in <a href='us_se_alaska.html' class='local'>us se alaska</a>, we used it underway to charge our laptops on days when there wasn't enough sun.</p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Oct 11 08:31:16 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/regulator.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/repair.html
+++ b/site/repair.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; repair</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; repair</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -348,108 +448,105 @@
 
 <img src='../media/content/knowledge/varnish.jpg' title='devine varnishing the tiller' loading='lazy' />
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Thu Nov  7 09:30:07 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Fri Nov 15 23:50:20 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/repair.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/resources.html
+++ b/site/resources.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; resources</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; resources</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -104,108 +204,105 @@
 </ul>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/resources.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/ronin.html
+++ b/site/ronin.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; ronin</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; ronin</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -179,108 +279,105 @@ $poly "red")
 <h2 id='pull_request'><a href='pull_request.html'>pull request</a></h2>
 <p>See the <a href='https://github.com/hundredrabbits/' target='_blank'>Github</a> and <a href='https://git.sr.ht/~rabbits/' target='_blank'>Sourcehut</a> repositories. Pull Requests are welcome, but please read our design <a href='philosophy.html' class='local'>philosophy</a> first. </p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Oct 16 16:27:05 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/ronin.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/roscoe_bay.html
+++ b/site/roscoe_bay.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; roscoe bay</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; roscoe bay</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -95,108 +195,105 @@
 
 <img src='../media/content/cooking/solar_cake2.jpg' alt='a solar cooked chocolate chip cake' loading='lazy'>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat Jul 15 09:50:39 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/roscoe_bay.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/ruth_island_cove.html
+++ b/site/ruth_island_cove.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; ruth island cove</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; ruth island cove</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -46,108 +146,105 @@
 
 <p>Due to light winds in Frederick Sound, we stayed here for 4 days. I did a lot of <a href='solar_cooking.html' class='local'>solar cooking</a> while here, because the sun was with us the whole time too. I cooked seitan, potatoes, brown rice, split green peas and made some <a href="https://grimgrains.com/site/okonomiyaki.html" target="_blank">okonomiyaki</a>! For the okonomiyaki, I made a chickpea flour and water mix with some chopped cabbage, spooned it in the tray of the cooker and cooked it for an hour and a half. It cooked fine, I then warmed the sauce and cut some green onions and threw it all overtop. It was very, very delicious.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Jun 19 17:54:27 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/ruth_island_cove.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/safety_gear.html
+++ b/site/safety_gear.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; safety gear</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; safety gear</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -117,108 +217,105 @@
 </ul>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Thu Nov  7 09:29:24 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Fri Nov 15 23:50:20 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/safety_gear.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/sailing.html
+++ b/site/sailing.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; sailing</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; sailing</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -390,108 +490,105 @@
 
 <p>A downside to insurance companies is that they are slowly pricing out small yacht owners. A machinist may not want to help a non-insured sailor with a small fix, because they can charge more to those with it. Small scale projects are not big money makers, and they are more likely to refuse them.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Thu Nov  7 09:28:29 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Fri Nov 15 23:50:20 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/sailing.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/sailing_in_japan.html
+++ b/site/sailing_in_japan.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; sailing in japan</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; sailing in japan</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -554,108 +654,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Apr 12 09:15:50 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/sailing_in_japan.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/saloon_hatch.html
+++ b/site/saloon_hatch.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; saloon hatch</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; saloon hatch</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -41,108 +141,105 @@
 <img src='../media/content/boat_projects/hatch_07.jpg' title='other view of hatch' loading='lazy'/>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Apr 26 17:26:51 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/saloon_hatch.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/satellite_phone.html
+++ b/site/satellite_phone.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; satellite phone</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; satellite phone</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -38,108 +138,105 @@ And so 124° 44.740 is 124.0.74566667 in Decimal Degrees.
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sun Jul 28 12:51:10 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/satellite_phone.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/saturna.html
+++ b/site/saturna.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; saturna</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; saturna</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -22,108 +122,105 @@
 
 <p>We didn't venture on land much on this visit, but we hope to next we go. We met some locals that live on the East Point of the island, and they offered to take us around! There are a few farms on the island, even fresh olives apparently. The climate here is perfect for it.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sun Mar 12 14:39:39 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/saturna.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/saving_fuel.html
+++ b/site/saving_fuel.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; saving fuel</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; saving fuel</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -23,108 +123,105 @@
   <li><b>Cook with the sun.</b> Uses zero fuel, only requires careful planning. See <a href='solar_cooking.html' class='local'>solar cooking</a>.</li>
 </ul>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Apr  3 12:13:02 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/saving_fuel.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/schedule.html
+++ b/site/schedule.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; schedule</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; schedule</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -6,108 +106,105 @@
 
 <p>Sailing with a schedule is a recipe for disaster, too many things can happen on a boat and arriving on a precise date can be difficult. Making plans will make you do bad decisions, leaving in bad weather to make a meeting for instance, can be dangerous. Sail with the weather, not against it.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/schedule.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/seasickness.html
+++ b/site/seasickness.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; seasickness</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; seasickness</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -12,108 +112,105 @@
     <li>If everything else fails, take the helm.</li>
 </ul>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/seasickness.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/setup.html
+++ b/site/setup.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; setup</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; setup</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -22,108 +122,105 @@
 <p><b>Note:</b> We are always looking for used laptops, if you can help us on that front, let us know at <b>rabbits ౷ 100r · co</b>.</p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Tue Oct 29 09:45:24 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/setup.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/sewing.html
+++ b/site/sewing.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; sewing</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; sewing</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -18,108 +118,105 @@
 
 <p><b>Note</b><i>: In December 2023 we got our own <a href="../media/content/inventory/sailrite_01.jpg">Sailrite Ultrafeed LSZ</a> sewing machine to be able to do more complex projects (see <a href='upholstery.html' class='local'>upholstery</a>).</i></p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Oct 23 08:24:20 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/sewing.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/shimoda.html
+++ b/site/shimoda.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; shimoda</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; shimoda</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -78,108 +178,105 @@
 
 <p>NOTE: we arrived safely in <a href='victoria.html' class='local'>Victoria</a>, BC on July 28th 2020. We published a book on our 51-day transit called <a href='busy_doing_nothing.html' class='local'>busy doing nothing</a>.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/shimoda.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/shoal_bay.html
+++ b/site/shoal_bay.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; shoal bay</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; shoal bay</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -12,108 +112,105 @@
 
 <p>The forecast was still 25-35 knots out of the NW in Johnstone Strait that day, we felt some gusts while in Shoal Bay, but not for long. The back channels are very shielded from the wind and chaos of the Strait. Wind can reach upper channels, especially if it's roaring out there, and especially if you're transiting in the shoulder season like we are. It rained a bit in the afternoon, enough that it helped rinse some of the salt from out boat, leftover from our bashing into weather when going up Malaspina Strait. Fresh water is a precious commodity here, we can't wash out boat with it, it is better to wait for rain.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Tue May 14 13:35:35 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/shoal_bay.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/shore_power_cord_repair.html
+++ b/site/shore_power_cord_repair.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; shore power cord repair</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; shore power cord repair</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -53,108 +153,105 @@
 
 <img src='../media/content/boat_projects/powercord_06.jpg' loading='lazy'>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Apr 26 17:20:11 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/shore_power_cord_repair.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/shower.html
+++ b/site/shower.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; shower</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; shower</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -9,108 +109,105 @@
 <p>In the winter, if we have no land access we heat up water on the stove and clean ourselves with a bucket and rag. We don't shower daily, maybe twice a week (depending on activity level).</p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Tue Jul  4 08:43:34 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/shower.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/sitka.html
+++ b/site/sitka.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; sitka</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; sitka</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -36,108 +136,105 @@
 
 <img src='../media/content/travel/sitka_06.jpg' alt='a totem pole featuring ravens and a whale' loading='lazy'>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Tue Jul  2 16:30:57 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/sitka.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/sky_reading.html
+++ b/site/sky_reading.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; sky reading</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; sky reading</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -100,108 +200,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Tue Oct  8 11:34:06 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/sky_reading.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/small_space.html
+++ b/site/small_space.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; small space</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; small space</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -20,108 +120,105 @@
 
 <p>In all, we like living in a small space. Making so-called inconvenient choices exposes us to a risk of frustration and failure, but there is much to gain from doing these things.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/small_space.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/smuggler_cove.html
+++ b/site/smuggler_cove.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; smuggler cove</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; smuggler cove</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -90,108 +190,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Dec  4 10:28:39 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/smuggler_cove.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/snubber.html
+++ b/site/snubber.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; snubber</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; snubber</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -10,108 +110,105 @@
 
 <p>Using a chain hook works, but in calmer conditions it might slip off (we've had that happen many times). It is better to use a rolling hitch to secure the line to the chain.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/snubber.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/snug_cove.html
+++ b/site/snug_cove.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; snug cove</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; snug cove</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -39,108 +139,105 @@
 
 <p>That day, we had planned to go to Exchange Cove on the north east of Prince of Wales Island(this same island), but the wind was too weak to sail all 35 NM, so we stopped at <a href='ratz_harbor.html' class='local'>Ratz Harbor</a>- that...was a mistake. The SE wind began as we arrived, but we knew we couldn't make it to either Coffman Cove or Exchange Cove before the tide turning, so Ratz Harbor seemed like a good place to overnight in south winds...it wasn't, at least it wasn't because a few hours into our stay the wind turned to the north, putting us in a lee shore. We left, and went back to Snug Cove... yet again.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sun Jun  9 15:06:09 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/snug_cove.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/software.html
+++ b/site/software.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; software</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; software</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -8,108 +108,105 @@
 <p>In our first year, we struggled to download 10gb software updates on slow Polynesian internet. Processor-intensive software or apps is a strain on limited power and bandwidth, but it doesn't have to be that way. The way developers write them can affect the power consumption of the resulting product. Chat rooms and bare bones text editors aren't supposed to be process-heavy, and yet the popular communication platform Slack requires <a href='https://josephg.com/blog/electron-is-flash-for-the-desktop/'>outrageous amounts of ram and CPU</a> to function. This is because Slack is embedding the entirety of Google Chrome in their app. Making software this way is costly to off-grid users, or those on slow connections, but luckily there are many alternatives. See <a href='https://github.com/everestpipkin/tools-list' target='_blank'>TinyTools</a> and <a href='https://github.com/mayfrost/guides/blob/master/ALTERNATIVES.md' target='_blank'>Bloatware Alternatives</a>.</p>
 <p>Our computer batteries should not need to grow ever larger only to support these bloatwares, nor should we need to add extra solar to power them. Just as you would look at the nutritional content of food products at the grocery store, find out how much energy your apps are consuming.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/software.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/sointula.html
+++ b/site/sointula.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; sointula</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; sointula</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -29,108 +129,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sun Aug 11 11:11:33 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/sointula.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/solar.html
+++ b/site/solar.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; solar</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; solar</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -48,108 +148,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Apr 26 17:28:38 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/solar.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/solar_box_cooking.html
+++ b/site/solar_box_cooking.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; solar box cooking</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; solar box cooking</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -10,108 +110,105 @@
 
 <p><b>Note</b>. We don't have much experience with this, but we plan to build a simple design soon to experiment with.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Apr  3 10:53:17 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/solar_box_cooking.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/solar_cooking.html
+++ b/site/solar_cooking.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; solar cooking</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; solar cooking</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -42,108 +142,105 @@
 <li><a href='solar_evacuated_tube_cooking.html' class='local'>Solar evacuated tube cooking</a></li>
 </ul>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Apr  3 10:59:57 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/solar_cooking.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/solar_cooking_experiment.html
+++ b/site/solar_cooking_experiment.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; solar cooking experiment</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; solar cooking experiment</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -178,108 +278,105 @@
 	<li><b>Black beans</b>.<br><b>Conditions:</b> Overcast. 25°C, fresh breeze.<br><b>Cooking time:</b> Started at 10h30, stopped at noon.<br><b>Date:</b> 2023.07.13.<br><b>Notes:</b> Soaked beans overnight, was overcast at first but then got sunny (like yesterday). Beans may cook faster otherwise.</li>
 </ul>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Tue Apr  9 09:41:51 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/solar_cooking_experiment.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/solar_evacuated_tube_cooking.html
+++ b/site/solar_evacuated_tube_cooking.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; solar evacuated tube cooking</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; solar evacuated tube cooking</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -118,108 +218,105 @@
 <li><a href='https://youtu.be/grU3bzaGH4o' target='_blank'>Cuisson au tube solaire</a> by NVHD (FR).</li>
 <li><a href='https://www.dusoleildansnosassiettes.com/boutique' target='_blank'>Du Soleil Dans Nos Assiettes</a>(FR, with EN translation).</li>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Tue Apr  9 09:41:26 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/solar_evacuated_tube_cooking.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/solar_tips.html
+++ b/site/solar_tips.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; solar tips</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; solar tips</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -161,108 +261,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Apr 14 08:21:24 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/solar_tips.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/sprouting.html
+++ b/site/sprouting.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; sprouting</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; sprouting</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -31,108 +131,105 @@
 <img src='../media/content/cooking/hydro2.jpg' title='lentil microgreens' alt='a hand holding a bundle of lentil microgreens, tilting the bundle to show the roots' loading='lazy'/>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Mar 15 10:18:22 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/sprouting.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/squalls.html
+++ b/site/squalls.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; squalls</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; squalls</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -15,108 +115,105 @@
 
 <p>The doldrums is an area where prevailing winds converge, creating an area of perpetual calms. In such places we use squalls to move forward, effectively becoming storm chasers. Squalls are just another means of propulsion on a quiet ocean. We chase squalls for their wind and for their water. Water is not hard to come by when there are squalls around. We always make sure to have a bucket on deck to attach to the end of the boom to collect it.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/squalls.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/standing_rigging_replacement.html
+++ b/site/standing_rigging_replacement.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; standing rigging replacement</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; standing rigging replacement</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -60,108 +160,105 @@
 
 <p>Because the weather was kind we got to replace the sheave at the top of the mast on the same day that we took it off. It is very rare for us to go up the mast twice in the same day. </p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat Apr 27 11:44:41 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/standing_rigging_replacement.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/store.html
+++ b/site/store.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; store</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; store</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -171,108 +271,105 @@
 
 <p>Thank you for your support!</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Nov 15 11:19:04 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Fri Nov 15 23:50:20 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/store.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/story.html
+++ b/site/story.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; story</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; story</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -15,108 +115,105 @@
 <q>Let's try to go slow, and fix things.</q>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Tue Aug  6 16:30:04 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/story.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/sturt_bay.html
+++ b/site/sturt_bay.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; sturt bay</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; sturt bay</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -74,108 +174,105 @@
 <p>We arrived in <a href='ballet_bay.html' class='local'>Ballet Bay</a> on Nelson Island at 1330.</p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Sep  4 17:45:18 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/sturt_bay.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/sun_driers.html
+++ b/site/sun_driers.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; sun driers</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; sun driers</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -14,108 +114,105 @@
 
 <p>Check that each piece is dried uniformly, and pack them in airtight containers. For long-term, it is a good idea to vacuum seal them, or to add packets of food-safe dessicants. Properly stored, dried fruits keep well for six to 12 months. The reconstituted food retains most nutrients. We like to add them to pasta or rice water while cooking.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sun Oct 23 10:38:20 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/sun_driers.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/support.html
+++ b/site/support.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; support</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; support</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -32,108 +132,105 @@
 
 <p>Thank you, a very brief way of expressing our boundless gratitude.<br/><b>Rek & Devine</b></p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Nov 11 11:06:20 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Fri Nov 15 23:50:20 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/support.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/teapot.html
+++ b/site/teapot.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; teapot</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; teapot</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -34,108 +134,105 @@
 
 <p><b>2024.03.03.</b> The seat that our dinghy came with had a very bad crack, we didn't much like the design so we didn't keep it. This year, someone in the marina put a dinghy seat in the trash, we rescued it and installed it on Teapot :)! We also added some carbon sheeting to the ends of the oars, and near where the fins start to re-enforce the wood. When rowing, we often hit the end of the oars on rocks when trying to get away from shore.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Tue Sep 24 12:23:56 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/teapot.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/telegraph_cove.html
+++ b/site/telegraph_cove.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; telegraph cove</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; telegraph cove</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -22,108 +122,105 @@
 
 <p>Our next stop, was <a href='port_mcneill.html' class='local'>Port McNeill</a>.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Tue May 21 19:49:35 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/telegraph_cove.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/tenedos_bay.html
+++ b/site/tenedos_bay.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; tenedos bay</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; tenedos bay</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -56,108 +156,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sun Mar 12 15:24:32 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/tenedos_bay.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/the_promise_of_pancakes.html
+++ b/site/the_promise_of_pancakes.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; the promise of pancakes</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; the promise of pancakes</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -101,108 +201,105 @@
 <p>To find out more about clearing into the Marshall Islands, read <a href='http://www.sailingmarshallislands.com/marshall-islands-info/' target='_blank'>this guide</a> by the <b>Mieco Beach Yacht Club</b>. Entry procedures change a lot from year to year, but SV Seal are on top of it and they're the best people to contact if you're planning on adding this stop to your list.
            
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Thu Mar 21 11:27:44 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/the_promise_of_pancakes.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/the_rock_of_polynesia.html
+++ b/site/the_rock_of_polynesia.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; the rock of polynesia</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; the rock of polynesia</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -75,108 +175,105 @@
 <p><a href='https://www.youtube.com/watch?v=6C1_2X74iXo' target='_blank' class='external'>Watch a video</a> of our time in Niue.</p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Tue Apr 30 08:02:35 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/the_rock_of_polynesia.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/thousand_rooms.html
+++ b/site/thousand_rooms.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; thousand rooms</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; thousand rooms</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -53,108 +153,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Oct 16 16:22:14 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/thousand_rooms.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/thruhulls.html
+++ b/site/thruhulls.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; thruhulls</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; thruhulls</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -138,108 +238,105 @@
 <p>We let the caulking dry and filled the locker with water to test the seal. No leaks, from either thru-hulls.</p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Apr 26 17:19:12 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/thruhulls.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/tonga.html
+++ b/site/tonga.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; tonga</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; tonga</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -52,108 +152,105 @@
 
 <img src='../media/content/travel/tonga_07.jpg' title='sailing into neiafu during a squall' loading='lazy'>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Feb 27 10:15:56 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/tonga.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/toolbox.html
+++ b/site/toolbox.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; toolbox</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; toolbox</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -140,108 +240,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Thu Nov  7 09:30:36 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Fri Nov 15 23:50:20 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/toolbox.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/tools_ecosystem.html
+++ b/site/tools_ecosystem.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; tools ecosystem</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; tools ecosystem</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -106,108 +206,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Feb 27 09:57:32 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/tools_ecosystem.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/turnip.html
+++ b/site/turnip.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; turnip</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; turnip</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -10,108 +110,105 @@
 
 <p>On April 10th 2021, Turnip was passed down to another owner. We have plans to get a rowing dinghy, and will not need a powered engine anymore.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/turnip.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/twilight.html
+++ b/site/twilight.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; twilight</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; twilight</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -24,108 +124,105 @@
 <p>When at either Poles, around winter solstice, the solar declination changes slowly and results in several weeks of complete darkness. The further you get from the Poles, the more twilight you'll experience on the same dates.</p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Thu Nov  7 09:25:43 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Fri Nov 15 23:50:20 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/twilight.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/typhoons_and_mold.html
+++ b/site/typhoons_and_mold.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; typhoons and mold</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; typhoons and mold</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -184,108 +284,105 @@
 </ul>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sun Apr  7 10:51:31 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/typhoons_and_mold.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/united_states.html
+++ b/site/united_states.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; united states</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; united states</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -21,108 +121,105 @@
 <p><b>Summer 2024 (southeast AK):</b><br><i>Foggy Bay > <a href='ketchikan.html' class='local'>Ketchikan</a> > <a href='snug_cove.html' class='local'>Snug Cove</a> > <a href='ratz_harbor.html' class='local'>Ratz Harbor</a> > Snug Cove > <a href='frosty_bay.html' class='local'>Frosty Bay</a> > <a href='berg_bay.html' class='local'>Berg Bay</a> > <a href='wrangell.html' class='local'>Wrangell</a> > Deception Point Cove > <a href='petersburg.html' class='local'>Petersburg</a> > <a href='ruth_island_cove.html' class='local'>Ruth Island Cove</a> > Portage Bay(Kupreanof Is.)> Duck Point (Cape Fanshaw) > Chapin Bay(Admiralty Is.) > Eva Is.(Baranof Is.) > Baby Bear Bay(Baranof Is.) > Piper Island > <a href='sitka.html' class='local'>Sitka</a> > Sandy Bay(Baranof Is.) > Port Bazan(Dall Is.) > <a href='prince_rupert.html' class='local'>Prince Rupert</a>(back to Canada).</i></p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Jul 22 11:14:24 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/united_states.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/upholstery.html
+++ b/site/upholstery.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; upholstery</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; upholstery</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -103,108 +203,105 @@
 
 <p>We have found that the airing material with an organized mesh collapses more readily than those that don't, the. We bought a sheet from two different sources to test both designs. The design with the organized mesh could still help to keep cushions dry, but may not be as useful when placed under a lot of weight. We'll let you know how both have performed in the spring.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Dec 29 12:14:25 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/upholstery.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/us_se_alaska.html
+++ b/site/us_se_alaska.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; us se alaska</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; us se alaska</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -88,108 +188,105 @@
 <p><b>Sandy Bay</b>. This anchorage on the west coast of Baranof Island is easy to enter with north winds, the entrance is shieled by land and rocks. It is about 2.5 nautical miles to the north anchorage(56°28.680'N, 134°57.900'W, not our anchor position, but general location of the anchorage). There is an anchorage on the way to the north anchorage(56°28.030'N, 134°58.430'W-we didn't try it). It is also possible to anchor near the waterfall, a large motor yacht was there when we arrived. In the north anchorage, we dropped the hook in 38 feet(about 42 at high tide). Holding seemed good, but the wind was not strong that day(10-15 knots out of the northwest). We were here on July 3rd.</p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Jul 22 11:12:34 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/us_se_alaska.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/us_west_coast.html
+++ b/site/us_west_coast.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; us west coast</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; us west coast</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -47,108 +147,105 @@
 <p>We loved our time here. Our favorite part of the trip was seeing the landscape change as we moved south, from lush green to orange and deserted. The United States occupies a large, and varied territory. Its people are kind, and generous. When we had problems, no one refused to help us—well, aside from those fishermen. We had a great time, and wish we could have made many more stops.</p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/us_west_coast.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/uxn.html
+++ b/site/uxn.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; uxn</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; uxn</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -108,108 +208,105 @@ bin/uxnemu path/to/example.rom
 <img src='../media/content/projects/uxn_01.jpg' alt='a screenshot of Noodle, a sketching tool. On the canvas there is a pixelated image featuring Tima from the movie Metropolis' title='Noodle, image is Tima from the movie Metropolis' loading='lazy' />
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Oct 16 16:25:48 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/uxn.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/uxn_design.html
+++ b/site/uxn_design.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; uxn design</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; uxn design</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -39,108 +139,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat Feb 18 09:23:04 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/uxn_design.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/uxn_guide.html
+++ b/site/uxn_guide.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; uxn guide</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; uxn guide</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -72,108 +172,105 @@ bin/uxnemu path/to/example.rom
 </ul>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Thu Feb 15 21:52:03 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/uxn_guide.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/verreciel.html
+++ b/site/verreciel.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; verreciel</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; verreciel</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -18,108 +118,105 @@
 <img src='../media/content/projects/verreciel_02.jpg' loading='lazy' />
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Oct 16 16:23:53 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/verreciel.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/victoria.html
+++ b/site/victoria.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; victoria</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; victoria</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -55,108 +155,105 @@
 
 <img src='../media/content/travel/victoria_05.jpg' alt='red christmas' loading='lazy'>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat Apr 20 11:03:08 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/victoria.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/victoria_to_sitka_logbook.html
+++ b/site/victoria_to_sitka_logbook.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; victoria to sitka logbook</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; victoria to sitka logbook</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -602,108 +702,105 @@
 
 <p>More coming soon...</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Nov  8 09:48:26 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Fri Nov 15 23:50:20 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/victoria_to_sitka_logbook.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/videos.html
+++ b/site/videos.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; videos</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; videos</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -329,108 +429,105 @@
     </li>
 </ul>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Thu Sep  7 12:20:49 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/videos.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/washing_dishes.html
+++ b/site/washing_dishes.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; washing dishes</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; washing dishes</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -15,108 +115,105 @@
 <p><b>5% Distilled white vinegar</b>. Vinegar is a good, inexpensive, nontoxic, cleaning agent and deodorizer, strong enough to kill household pathogens (note that it doesn't kill them all, it's inneffective against salmonella) [<a href="https://www.hsph.harvard.edu/nutritionsource/food-features/vinegar/" target="_blank">Source</a>]. Dilute the vinegar with water 2:1.</p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Mar 18 20:19:30 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/washing_dishes.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/washing_produce.html
+++ b/site/washing_produce.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; washing produce</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; washing produce</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -7,108 +107,105 @@
 
 <p>Washing produce in baking soda prevents some foodborne illness and can reduce exposure to pesticides, it is more effective than using a vinegar solution (because it needs to be used full-strength, and that can get expensive). This washing technique is the same for fresh greens and fruits, although for berries it is best to wash them right before eating them.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Mar 18 10:30:11 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/washing_produce.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/waste.html
+++ b/site/waste.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; waste</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; waste</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -21,108 +121,105 @@
  
 <p>See our <a href='dry_toilet_installation.html' class='local'>dry toilet installation</a>.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Thu Nov  7 09:23:31 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Fri Nov 15 23:50:20 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/waste.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/water.html
+++ b/site/water.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; water</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; water</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -13,108 +113,105 @@
 <p>Related: <a href='water_storage.html' class='local'>water storage</a>, <a href='water_filtration.html' class='local'>water filtration</a> & <a href='rain.html' class='local'>rain</a>.</p>
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Nov  3 13:57:47 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/water.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/water_filtration.html
+++ b/site/water_filtration.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; water filtration</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; water filtration</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -16,108 +116,105 @@
 
 <p>For low-tech options, check out this <a href='https://wiki.lowtechlab.org/wiki/Filtre_%C3%A0_eau_c%C3%A9ramique/en' target='_blank'>ceramic filter</a>, or the <a href='https://www.youtube.com/watch?v=232xA2e8RiQ' target='_blank'>3 bucket water filtration system</a>. We aimed for the most compact, and practical system possible, even if it isn't the cheapest.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/water_filtration.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/water_storage.html
+++ b/site/water_storage.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; water storage</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; water storage</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -14,108 +114,105 @@
 
 <p>Pino has no watermaker, and doesn't want one. See our <a href='water_filtration.html' class='local'>water filtration</a> systems.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/water_storage.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/weather.html
+++ b/site/weather.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; weather</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; weather</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -249,108 +349,105 @@
 
 <p>This is the scale that we use in our book <a href='busy_doing_nothing.html' class='local'>Busy Doing Nothing</a>.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Jun  3 20:27:52 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/weather.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/weathering_software_winter.html
+++ b/site/weathering_software_winter.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; weathering software winter</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; weathering software winter</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -337,108 +437,105 @@
 
 <p>Thank you for reading.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Sep 13 08:59:53 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/weathering_software_winter.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/website.html
+++ b/site/website.html
@@ -1,111 +1,208 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; website</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; website</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
 <h1>website</h1><p>This wiki is statically generated from a small C89 program, the sources are available <a href='https://github.com/hundredrabbits/100r.co/' target='_blank'>here</a>, if you find a typo, a broken link or have a code specific question, feel free to open an <a href='https://github.com/hundredrabbits/100r.co/issues/new' target='_blank'>issue</a>.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat May  7 15:50:14 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/website.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/western_canada.html
+++ b/site/western_canada.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; western canada</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; western canada</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -187,108 +287,105 @@
 <img src='../media/content/travel/saturna_01.jpg' title='Rek rowing around lyall harbor' alt='rowing teapot around Lyall harbor on saturna island' loading='lazy'>
 <img src='../media/content/travel/pl_30.jpg' alt='pino sailing out of Princess Louisa Inlet' loading='lazy'>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Sep 30 20:18:45 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/western_canada.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/wheel_to_tiller_conversion.html
+++ b/site/wheel_to_tiller_conversion.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; wheel to tiller conversion</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; wheel to tiller conversion</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -96,108 +196,105 @@
 
 <p>It's a bit clunky-looking, but it's a good temporary solution. We plan to make a cap to keep water from entering the top of the pipe.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Apr 19 21:14:09 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/wheel_to_tiller_conversion.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/where.html
+++ b/site/where.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; where</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; where</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -19,108 +119,105 @@
 
 <p>View the <a href="https://100r.co/live/">interactive map</a> for details.</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Sep 30 20:17:27 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/where.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/why_a_boat.html
+++ b/site/why_a_boat.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; why a boat</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; why a boat</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -17,108 +117,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Thu Nov  7 09:19:40 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Fri Nov 15 23:50:20 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/why_a_boat.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/wiktopher.html
+++ b/site/wiktopher.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; wiktopher</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; wiktopher</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -76,108 +176,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Mon Nov 11 11:00:16 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Fri Nov 15 23:50:20 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/wiktopher.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/windlass_removal.html
+++ b/site/windlass_removal.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; windlass removal</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; windlass removal</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -42,108 +142,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Sep 18 08:20:39 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/windlass_removal.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/window_replacement.html
+++ b/site/window_replacement.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; window replacement</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; window replacement</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -83,108 +183,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Apr 26 17:17:47 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/window_replacement.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/wood_upkeep.html
+++ b/site/wood_upkeep.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; wood upkeep</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; wood upkeep</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -8,108 +108,105 @@
 
 <img src='../media/content/knowledge/varnish.jpg' title='devine varnishing the tiller' loading='lazy' />
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sun Nov 19 11:24:26 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/wood_upkeep.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/woodstove.html
+++ b/site/woodstove.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; woodstove</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; woodstove</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -28,108 +128,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Sat Nov  5 13:57:47 2022
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/woodstove.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/woodstove_installation.html
+++ b/site/woodstove_installation.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; woodstove installation</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; woodstove installation</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -220,108 +320,105 @@ of the pipe and into the trough. We won't be sailing with it on deck, we'll swap
 
 <p>We will have to redo the deck ring...</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Oct 11 08:55:21 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/woodstove_installation.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/working_offgrid_efficiently.html
+++ b/site/working_offgrid_efficiently.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; working offgrid efficiently</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; working offgrid efficiently</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -100,108 +200,105 @@
 
 
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Jun 28 19:58:50 2023
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 12:48:26 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/working_offgrid_efficiently.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/wrangell.html
+++ b/site/wrangell.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; wrangell</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; wrangell</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -34,108 +134,105 @@
 
 <p>We spent 2 days here, both were devoid of wind... a good time to stay put. Both days were warm, and sunny... it is like summer had finally come to this part of the world. We enjoyed watching the eagles hound the fisherman just returning with the day's catch, they find a perch near them and keep watch, waiting for scraps. One eagle tried to land on the masthead of a sailboat, we cringed a little when we saw its talons bite at the instruments mounted there, trying to find a comfortable foothold. In the end, it grew tired of trying and found a spot on a fishing boat rig. We've had plenty of time lately to observe eagles from up close, they're such beautiful birds, although they seem to rely on local fishermen a lot for food...</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Wed Jun 19 12:28:43 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/wrangell.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/site/yuculta_and_dent_rapids.html
+++ b/site/yuculta_and_dent_rapids.html
@@ -1,4 +1,104 @@
-<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; yuculta and dent rapids</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><main>
+<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'><meta name='thumbnail' content='https://100r.co/media/services/rss.jpg' /><meta name='viewport' content='width=device-width,initial-scale=1'><link rel='alternate' type='application/rss+xml' title='RSS Feed' href='../links/rss.xml' /><link rel='stylesheet' type='text/css' href='../links/main.css'><link rel='shortcut icon' type='image/png' href='../media/services/shortcut.png'><title>100R &mdash; yuculta and dent rapids</title></head><body><header><a href='home.html'><img src='../media/interface/logo.svg' alt='100R' height='65'></a></header><nav><details><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><main>
 
 <!-- Generated file, do not edit -->
 
@@ -56,108 +156,105 @@
 
 <p><a href='shoal_bay.html' class='local'>Shoal Bay</a> is a good place to wait before tackling the rapids, but it is very popular in the high summer. Other options include Bickley Bay - although if high NW winds are forecast for Johnstone Strait, make sure your anchor is set well because the gusts that swirl in there are very strong. There is also good anchoring in Tallac Bay and the Cordero Islands. The closer you anchor to Green Point Rapids the harder it will be for a slow boat to leave early to catch slack at Dents, because the current can be quite strong in that area on a big tide. There are other anchorages in Nodales Channel too, but you'll also have to buck a bit of current to get to the Dents(we haven't tried any anchorage there yet).</p>
 
-</main><nav><details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='index.html' class='local'>index</a></li>
-            </ul>
-        </section>
+</main><nav><details open><summary>Menu</summary><section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
-</nav><footer><hr /><span style='float:right'>Edited on Fri Aug 16 08:54:39 2024
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='index.html' class='local'>index</a></li>
+        </ul>
+    </section>
+</section>
+</details></nav><footer><hr /><span style='float:right'>Edited on Thu Oct 31 13:08:54 2024
  <a href='https://github.com/hundredrabbits/100r.co/edit/main/src/inc/yuculta_and_dent_rapids.htm'>[edit]</a><br/></span><b>Hundredrabbits</b> © 2024 — <a href='https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md' target='_blank'>BY-NC-SA 4.0</a><a href='https://merveilles.town/@neauoire' rel='me' class='hidden'></a><a href='https://merveilles.town/@rek' rel='me' class='hidden'></a></footer></body></html>

--- a/src/inc/meta.nav.htm
+++ b/src/inc/meta.nav.htm
@@ -1,103 +1,100 @@
-<details open>
-    <summary>Menu</summary>
-    <section class="site-nav">
-        <section>
-            <ul class='nobull capital'>
-                <li><a href='about_us.html'>about us</a></li>
-                <li><a href='mission.html'>mission</a></li>
-                <li><a href='philosophy.html'>philosophy</a></li>
-                <li><a href='pino.html'>pino</a></li>
-                <li><a href='videos.html'>videos</a></li>
-                <li><a href='support.html'>support</a></li>
-                <li><a href='store.html'>store</a></li>
-                <li><a href='press.html'>press</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='knowledge'>knowledge</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='off_the_grid.html'>off the grid</a></li>
-                <li><a href='liveaboard.html'>liveaboard</a></li>
-                <li><a href='sailing.html'>sailing</a></li>
-                <li><a href='cooking.html'>cooking</a></li>
-                <li><a href='repair.html'>repair</a></li>
-                <li><a href='costs.html'>costs</a></li>
-                <li><a href='engine_care.html'>engine care</a></li>
-                <li><a href='weather.html'>weather</a></li>
-                <li><a href='resources.html'>resources</a></li>
-                <li><a href='rabbit_waves.html'>rabbit waves</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='blog'>blog</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='log.html'>log</a></li>
-                <li><a href='boat_projects.html'>Boat projects</a></li>
-                <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
-                <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
-                <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
-                <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
-                <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
-                <li><a href='logbooks.html'>Logbooks</a></li>
-                <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='tools'>tools</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='noodle.html'>noodle</a></li>
-                <li><a href='orca.html'>orca</a></li>
-                <li><a href='dotgrid.html'>dotgrid</a></li>
-                <li><a href='ronin.html'>ronin</a></li>
-                <li><a href='left.html'>left</a></li>
-                <li><a href='nasu.html'>nasu</a></li>
-                <li><a href='uxn.html'>uxn</a></li>
-                <li><a href='adelie.html'>adelie</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='games'>games</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='niju.html'>niju</a></li>
-                <li><a href='markl.html'>markl</a></li>
-                <li><a href='oquonie.html'>oquonie</a></li>
-                <li><a href='donsol.html'>donsol</a></li>
-                <li><a href='paradise.html'>paradise</a></li>
-                <li><a href='hiversaires.html'>hiversaires</a></li>
-                <li><a href='verreciel.html'>verreciel</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='books'>books</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='thousand_rooms.html'>thousand rooms</a></li>
-                <li><a href='wiktopher.html'>wiktopher</a></li>
-                <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
-                <li><a href='library.html'>library</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='travel'>travel</a></h2>
-            <ul class='nobull capital'>
-                <li><a href='western_canada.html'>Western Canada</a></li>
-                <li><a href='united_states.html'>United States</a></li>
-                <li><a href='mexico.html'>Mexico</a></li>
-                <li><a href='french_polynesia.html'>French polynesia</a></li>
-                <li><a href='cook_islands.html'>Cook islands</a></li>
-                <li><a href='niue.html'>Niue</a></li>
-                <li><a href='tonga.html'>Tonga</a></li>
-                <li><a href='new_zealand.html'>New zealand</a></li>
-                <li><a href='fiji.html'>Fiji</a></li>
-                <li><a href='marshall_islands.html'>Marshall islands</a></li>
-                <li><a href='japan.html'>Japan</a></li>
-                <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
-            </ul>
-        </section>
-        <section>
-            <h2><a id='meta'>Meta</a></h2>
-            <ul class='nobull capital'>
-                <li>{index}</li>
-            </ul>
-        </section>
+<section class="site-nav">
+    <section>
+        <ul class='nobull capital'>
+            <li><a href='about_us.html'>about us</a></li>
+            <li><a href='mission.html'>mission</a></li>
+            <li><a href='philosophy.html'>philosophy</a></li>
+            <li><a href='pino.html'>pino</a></li>
+            <li><a href='videos.html'>videos</a></li>
+            <li><a href='support.html'>support</a></li>
+            <li><a href='store.html'>store</a></li>
+            <li><a href='press.html'>press</a></li>
+        </ul>
     </section>
-</details>
+    <section>
+        <h2><a id='knowledge'>knowledge</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='off_the_grid.html'>off the grid</a></li>
+            <li><a href='liveaboard.html'>liveaboard</a></li>
+            <li><a href='sailing.html'>sailing</a></li>
+            <li><a href='cooking.html'>cooking</a></li>
+            <li><a href='repair.html'>repair</a></li>
+            <li><a href='costs.html'>costs</a></li>
+            <li><a href='engine_care.html'>engine care</a></li>
+            <li><a href='weather.html'>weather</a></li>
+            <li><a href='resources.html'>resources</a></li>
+            <li><a href='rabbit_waves.html'>rabbit waves</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='blog'>blog</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='log.html'>log</a></li>
+            <li><a href='boat_projects.html'>Boat projects</a></li>
+            <li><a href='computing_and_sustainability.html'>Computing and Sustainability</a></li>
+            <li><a href='weathering_software_winter.html'>Weathering Software Winter</a></li>
+            <li><a href='working_offgrid_efficiently.html'>Working Offgrid Efficiently</a></li>
+            <li><a href='tools_ecosystem.html'>Tools Ecosystem</a></li>
+            <li><a href='solar_cooking_experiment.html'>Solar Cooking Experiment</a></li>
+            <li><a href='logbooks.html'>Logbooks</a></li>
+            <li><a href='buying_a_sailboat.html'>Buying a Sailboat</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='tools'>tools</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='noodle.html'>noodle</a></li>
+            <li><a href='orca.html'>orca</a></li>
+            <li><a href='dotgrid.html'>dotgrid</a></li>
+            <li><a href='ronin.html'>ronin</a></li>
+            <li><a href='left.html'>left</a></li>
+            <li><a href='nasu.html'>nasu</a></li>
+            <li><a href='uxn.html'>uxn</a></li>
+            <li><a href='adelie.html'>adelie</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='games'>games</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='niju.html'>niju</a></li>
+            <li><a href='markl.html'>markl</a></li>
+            <li><a href='oquonie.html'>oquonie</a></li>
+            <li><a href='donsol.html'>donsol</a></li>
+            <li><a href='paradise.html'>paradise</a></li>
+            <li><a href='hiversaires.html'>hiversaires</a></li>
+            <li><a href='verreciel.html'>verreciel</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='books'>books</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='thousand_rooms.html'>thousand rooms</a></li>
+            <li><a href='wiktopher.html'>wiktopher</a></li>
+            <li><a href='busy_doing_nothing.html'>busy doing nothing</a></li>
+            <li><a href='library.html'>library</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='travel'>travel</a></h2>
+        <ul class='nobull capital'>
+            <li><a href='western_canada.html'>Western Canada</a></li>
+            <li><a href='united_states.html'>United States</a></li>
+            <li><a href='mexico.html'>Mexico</a></li>
+            <li><a href='french_polynesia.html'>French polynesia</a></li>
+            <li><a href='cook_islands.html'>Cook islands</a></li>
+            <li><a href='niue.html'>Niue</a></li>
+            <li><a href='tonga.html'>Tonga</a></li>
+            <li><a href='new_zealand.html'>New zealand</a></li>
+            <li><a href='fiji.html'>Fiji</a></li>
+            <li><a href='marshall_islands.html'>Marshall islands</a></li>
+            <li><a href='japan.html'>Japan</a></li>
+            <li><a href='north_pacific_ocean.html'>North Pacific Ocean</a></li>
+        </ul>
+    </section>
+    <section>
+        <h2><a id='meta'>Meta</a></h2>
+        <ul class='nobull capital'>
+            <li>{index}</li>
+        </ul>
+    </section>
+</section>

--- a/src/main.c
+++ b/src/main.c
@@ -195,6 +195,11 @@ build(FILE *f, Lexicon *l, char *name, char *srcpath)
 	fputs("<header>", f);
 	fputs("<a href='home.html'><img src='../media/interface/logo.svg' alt='" NAME "' height='65'></a>", f);
 	fputs("</header>", f);
+	/* mobile nav */
+	fputs("<nav><details><summary>Menu</summary>", f);
+	if(!fpportal(f, l, "meta.nav", 0))
+		printf(">>> Building failed: %s\n", name);
+	fputs("</details></nav>", f);
 	/* main */
 	fputs("<main>\n\n", f);
 	fputs("<!-- Generated file, do not edit -->\n\n", f);
@@ -203,10 +208,10 @@ build(FILE *f, Lexicon *l, char *name, char *srcpath)
 		printf(">>> Building failed: %s\n", name);
 	fputs("\n\n</main>", f);
 	/* nav */
-	fputs("<nav>", f);
+	fputs("<nav><details open><summary>Menu</summary>", f);
 	if(!fpportal(f, l, "meta.nav", 0))
 		printf(">>> Building failed: %s\n", name);
-	fputs("</nav>", f);
+	fputs("</details></nav>", f);
 	/* footer */
 	fputs("<footer><hr />", f);
 	fpedited(f, srcpath);


### PR DESCRIPTION
Hey friends,

Currently, `<nav>` is after `<main>`. This works great on desktop, and it prevents the previous issues with mobile navigation overflowing.

However, on mobile, the navigation is currently only visible after scrolling all the way to the bottom. Readers visiting the homepage will not know this, and are unlikely to scroll to the bottom. And people looking for specific content on mobile will have a very difficult time navigating.

I changed the code to have two instances of `<nav>`. There's one after `<main>`, which works as it currently does, except that it is only visible on desktop. And there's a separate navigation for mobile only, before `<main>`, which starts out closed.

This means that mobile users see the “▸ Menu” right away, but they are free to expand it when they wish.

<img src="https://github.com/user-attachments/assets/eb397729-b099-48fd-9c01-d09b2ed875ec" width="400">

<img src="https://github.com/user-attachments/assets/9f6a6b02-04ed-4bd8-9a6d-ec516f317e62" width="400">

I think this makes navigating the website much easier.

It's easiest to review this PR by looking at this commit directly: https://github.com/hundredrabbits/100r.co/pull/107/commits/d65a99bbd5a11091652c7d6cc7ec337ed43946de

Wishing you a nice day,
Vlad