### PR TITLE
Reduce reflows and improve accessibility

### DIFF
--- a/links/main.css
+++ b/links/main.css
@@ -25,7 +25,7 @@ nav a img { width:144px; height:auto; display:block; }
 nav .hidden {position:absolute; overflow:hidden; left: -9999px}
 
 main { padding: 0px 0px 45px 45px; max-width:900px; }
-main img { width:100%; max-width: 900px; margin-bottom: 15px;}
+main img { width:100%; height:auto; max-width: 900px; margin-bottom: 15px;}
 main > * { max-width: 900px; margin-bottom: 30px }
 main > h1 { font-size:45px; text-transform: capitalize; display: none}
 main > h2 { font-size:30px; text-transform: capitalize}

--- a/links/main.css
+++ b/links/main.css
@@ -119,7 +119,7 @@ ul.nobull li {list-style-type: none}
 
 @media (prefers-color-scheme: dark) {
 	body {background: #000; color: white}
-	nav a img.text, img.invert, footer a.logo { filter: invert(1)}
+	nav a img.text, img.invert, footer a.logo { color:#000; filter: invert(1)}
 	body a { color: white;}
 	main > pre { background: white; color:#000}
 	main > code { background:white; color:#000}

--- a/links/main.css
+++ b/links/main.css
@@ -20,8 +20,8 @@ body.page_travel nav a.travel_rabbit img.active { display:block }
 body.page_travel nav a.travel_rabbit img.inactive { display:none }
 
 nav { padding: 20px 30px; max-width:900px; margin-top: 45px; margin-bottom:20px }
-nav a { display:inline-block; max-width: 16% }
-nav a img { width:100%; display:block; }
+nav a { display:inline-block; }
+nav a img { width:144px; height:auto; display:block; }
 nav .hidden {position:absolute; overflow:hidden; left: -9999px}
 
 main { padding: 0px 0px 45px 45px; max-width:900px; }

--- a/links/main.css
+++ b/links/main.css
@@ -135,10 +135,8 @@ ul.nobull li {list-style-type: none}
 /* Mobile */
 
 @media only screen and (max-width: 1100px) {
-
-nav a {display:inline-block; max-width: 25%}
-nav {padding: 20px;text-align: center}
-main {padding: 20px;}
-.gridprojects, .projects {grid-column-start: span 2;}
-.article, .grid, .featured {grid-column-start: span 3;}
+	nav {padding: 20px;text-align: center}
+	main {padding: 20px;}
+	.gridprojects, .projects {grid-column-start: span 2;}
+	.article, .grid, .featured {grid-column-start: span 3;}
 }

--- a/src/inc/home.htm
+++ b/src/inc/home.htm
@@ -1,3 +1,3 @@
-<img src='../media/content/about/galley.png' alt='an isometric drawing of the interior of a sailboat. Rek is stoking a woodstove, Little Ninj is updating his website at the nav table and Devine is cooking something tasty in the galley' loading='lazy' />
+<img src='../media/content/about/galley.png' alt='an isometric drawing of the interior of a sailboat. Rek is stoking a woodstove, Little Ninj is updating his website at the nav table and Devine is cooking something tasty in the galley' loading='lazy' width='900' height='438'/>
 
 {/log}

--- a/src/inc/meta.nav.htm
+++ b/src/inc/meta.nav.htm
@@ -10,33 +10,33 @@
 </nav>
 <nav>
 	<a href='home.html' class='home_rabbit' aria-label='Home'>
-		<img src='../media/interface/home.png' alt='a rabbit wearing a funky sweater'/>
-		<img class='text inactive' src='../media/interface/home_txt.png' alt='Home'/>
-		<img class='text active' src='../media/interface/home_txt_underline.png' alt='Home'/>
+		<img src='../media/interface/home.png' alt='a rabbit wearing a funky sweater' width='200' height='200'/>
+		<img class='text inactive' src='../media/interface/home_txt.png' alt='Home' width='200' height='35'/>
+		<img class='text active' src='../media/interface/home_txt_underline.png' alt='Home' width='200' height='35'/>
 	</a>
 	<a href='about.html' class='about_rabbit' aria-label='About'>
-		<img src='../media/interface/about.png' alt='a mariner rabbit with a spyglass, coiled in ropes'/>
-		<img class='text inactive' src='../media/interface/about_txt.png' alt='About'/>
-	<img class='text active' src='../media/interface/about_txt_underline.png' alt='About'/>
+		<img src='../media/interface/about.png' alt='a mariner rabbit with a spyglass, coiled in ropes' width='200' height='200'/>
+		<img class='text inactive' src='../media/interface/about_txt.png' alt='About' width='200' height='35'/>
+	<img class='text active' src='../media/interface/about_txt_underline.png' alt='About' width='200' height='35'/>
 	</a>
 	<a href='knowledge.html' class='knowledge_rabbit' aria-label='Knowledge'>
-		<img src='../media/interface/knowledge.png' alt='a rabbit holding some rolled up documents'/>
-		<img class='text inactive' src='../media/interface/knowledge_txt.png' alt='Knowledge'/>
-		<img class='text active' src='../media/interface/knowledge_txt_underline.png' alt='Knowledge'/>
+		<img src='../media/interface/knowledge.png' alt='a rabbit holding some rolled up documents' width='200' height='200'/>
+		<img class='text inactive' src='../media/interface/knowledge_txt.png' alt='Knowledge' width='200' height='35'/>
+		<img class='text active' src='../media/interface/knowledge_txt_underline.png' alt='Knowledge' width='200' height='35'/>
 	</a>
 	<a href='articles.html' class='articles_rabbit' aria-label='Articles'>
-		<img src='../media/interface/articles.png' alt='a rabbit laying on their belly and writing into a book'/>
-		<img class='text inactive' src='../media/interface/articles_txt.png' alt='Articles'/>
-		<img class='text active' src='../media/interface/articles_txt_underline.png' alt='Articles'/>
+		<img src='../media/interface/articles.png' alt='a rabbit laying on their belly and writing into a book' width='200' height='200'/>
+		<img class='text inactive' src='../media/interface/articles_txt.png' alt='Articles' width='200' height='35'/>
+		<img class='text active' src='../media/interface/articles_txt_underline.png' alt='Articles' width='200' height='35'/>
 	</a>
 	<a href='projects.html' class='projects_rabbit' aria-label='Projects'>
-		<img src='../media/interface/projects.png' alt='a rabbit working on a project, taking measurements while while a hard hat'/>
-		<img class='text inactive' src='../media/interface/projects_txt.png' alt='Projects'/>
-		<img class='text active' src='../media/interface/projects_txt_underline.png' alt='Projects'/>
+		<img src='../media/interface/projects.png' alt='a rabbit working on a project, taking measurements while while a hard hat' width='200' height='200'/>
+		<img class='text inactive' src='../media/interface/projects_txt.png' alt='Projects' width='200' height='35'/>
+		<img class='text active' src='../media/interface/projects_txt_underline.png' alt='Projects' width='200' height='35'/>
 	</a>
 	<a href='travel.html' class='travel_rabbit' aria-label='Travel'>
-		<img src='../media/interface/travel.png' alt='a rabbit sitting in a small boat wearing a rain coat'/>
-		<img class='text inactive' src='../media/interface/travel_txt.png' alt='Travel'/>
-		<img class='text active' src='../media/interface/travel_txt_underline.png' alt='Travel'/>
+		<img src='../media/interface/travel.png' alt='a rabbit sitting in a small boat wearing a rain coat' width='200' height='200'/>
+		<img class='text inactive' src='../media/interface/travel_txt.png' alt='Travel' width='200' height='35'/>
+		<img class='text active' src='../media/interface/travel_txt_underline.png' alt='Travel' width='200' height='35'/>
 	</a>
 </nav>

--- a/src/inc/meta.nav.htm
+++ b/src/inc/meta.nav.htm
@@ -11,32 +11,32 @@
 <nav>
 	<a href='home.html' class='home_rabbit' aria-label='Home'>
 		<img src='../media/interface/home.png' alt='a rabbit wearing a funky sweater'/>
-		<img class='text inactive' src='../media/interface/home_txt.png' title='Home'/>
-		<img class='text active' src='../media/interface/home_txt_underline.png' title='Home'/>
+		<img class='text inactive' src='../media/interface/home_txt.png' alt='Home'/>
+		<img class='text active' src='../media/interface/home_txt_underline.png' alt='Home'/>
 	</a>
 	<a href='about.html' class='about_rabbit' aria-label='About'>
 		<img src='../media/interface/about.png' alt='a mariner rabbit with a spyglass, coiled in ropes'/>
-		<img class='text inactive' src='../media/interface/about_txt.png' title='About'/>
-	<img class='text active' src='../media/interface/about_txt_underline.png' title='About'/>
+		<img class='text inactive' src='../media/interface/about_txt.png' alt='About'/>
+	<img class='text active' src='../media/interface/about_txt_underline.png' alt='About'/>
 	</a>
 	<a href='knowledge.html' class='knowledge_rabbit' aria-label='Knowledge'>
 		<img src='../media/interface/knowledge.png' alt='a rabbit holding some rolled up documents'/>
-		<img class='text inactive' src='../media/interface/knowledge_txt.png' title='Knowledge'/>
-		<img class='text active' src='../media/interface/knowledge_txt_underline.png' title='Knowledge'/>
+		<img class='text inactive' src='../media/interface/knowledge_txt.png' alt='Knowledge'/>
+		<img class='text active' src='../media/interface/knowledge_txt_underline.png' alt='Knowledge'/>
 	</a>
 	<a href='articles.html' class='articles_rabbit' aria-label='Articles'>
 		<img src='../media/interface/articles.png' alt='a rabbit laying on their belly and writing into a book'/>
-		<img class='text inactive' src='../media/interface/articles_txt.png' title='Articles'/>
-		<img class='text active' src='../media/interface/articles_txt_underline.png' title='Articles'/>
+		<img class='text inactive' src='../media/interface/articles_txt.png' alt='Articles'/>
+		<img class='text active' src='../media/interface/articles_txt_underline.png' alt='Articles'/>
 	</a>
 	<a href='projects.html' class='projects_rabbit' aria-label='Projects'>
 		<img src='../media/interface/projects.png' alt='a rabbit working on a project, taking measurements while while a hard hat'/>
-		<img class='text inactive' src='../media/interface/projects_txt.png' title='Projects'/>
-		<img class='text active' src='../media/interface/projects_txt_underline.png' title='Projects'/>
+		<img class='text inactive' src='../media/interface/projects_txt.png' alt='Projects'/>
+		<img class='text active' src='../media/interface/projects_txt_underline.png' alt='Projects'/>
 	</a>
 	<a href='travel.html' class='travel_rabbit' aria-label='Travel'>
 		<img src='../media/interface/travel.png' alt='a rabbit sitting in a small boat wearing a rain coat'/>
-		<img class='text inactive' src='../media/interface/travel_txt.png' title='Travel'/>
-		<img class='text active' src='../media/interface/travel_txt_underline.png' title='Travel'/>
+		<img class='text inactive' src='../media/interface/travel_txt.png' alt='Travel'/>
+		<img class='text active' src='../media/interface/travel_txt_underline.png' alt='Travel'/>
 	</a>
 </nav>

--- a/src/inc/meta.nav.htm
+++ b/src/inc/meta.nav.htm
@@ -9,34 +9,34 @@
 	</ul>
 </nav>
 <nav>
-	<a href='home.html' class='home_rabbit'>
+	<a href='home.html' class='home_rabbit' aria-label='Home'>
 		<img src='../media/interface/home.png' alt='a rabbit wearing a funky sweater'/>
 		<img class='text inactive' src='../media/interface/home_txt.png' title='Home'/>
 		<img class='text active' src='../media/interface/home_txt_underline.png' title='Home'/>
 	</a>
-	<a href='about.html' class='about_rabbit'>
+	<a href='about.html' class='about_rabbit' aria-label='About'>
 		<img src='../media/interface/about.png' alt='a mariner rabbit with a spyglass, coiled in ropes'/>
 		<img class='text inactive' src='../media/interface/about_txt.png' title='About'/>
 	<img class='text active' src='../media/interface/about_txt_underline.png' title='About'/>
 	</a>
-	<a href='knowledge.html' class='knowledge_rabbit'>
+	<a href='knowledge.html' class='knowledge_rabbit' aria-label='Knowledge'>
 		<img src='../media/interface/knowledge.png' alt='a rabbit holding some rolled up documents'/>
-		<img class='text inactive' src='../media/interface/knowledge_txt.png' title='knowledge'/>
-		<img class='text active' src='../media/interface/knowledge_txt_underline.png' title='knowledge'/>
+		<img class='text inactive' src='../media/interface/knowledge_txt.png' title='Knowledge'/>
+		<img class='text active' src='../media/interface/knowledge_txt_underline.png' title='Knowledge'/>
 	</a>
-	<a href='articles.html' class='articles_rabbit'>
+	<a href='articles.html' class='articles_rabbit' aria-label='Articles'>
 		<img src='../media/interface/articles.png' alt='a rabbit laying on their belly and writing into a book'/>
-		<img class='text inactive' src='../media/interface/articles_txt.png' title='articles'/>
-		<img class='text active' src='../media/interface/articles_txt_underline.png' title='articles'/>
+		<img class='text inactive' src='../media/interface/articles_txt.png' title='Articles'/>
+		<img class='text active' src='../media/interface/articles_txt_underline.png' title='Articles'/>
 	</a>
-	<a href='projects.html' class='projects_rabbit'>
+	<a href='projects.html' class='projects_rabbit' aria-label='Projects'>
 		<img src='../media/interface/projects.png' alt='a rabbit working on a project, taking measurements while while a hard hat'/>
-		<img class='text inactive' src='../media/interface/projects_txt.png' title='projects'/>
-		<img class='text active' src='../media/interface/projects_txt_underline.png' title='projects'/>
+		<img class='text inactive' src='../media/interface/projects_txt.png' title='Projects'/>
+		<img class='text active' src='../media/interface/projects_txt_underline.png' title='Projects'/>
 	</a>
-	<a href='travel.html' class='travel_rabbit'>
+	<a href='travel.html' class='travel_rabbit' aria-label='Travel'>
 		<img src='../media/interface/travel.png' alt='a rabbit sitting in a small boat wearing a rain coat'/>
-		<img class='text inactive' src='../media/interface/travel_txt.png' title='travel'/>
-		<img class='text active' src='../media/interface/travel_txt_underline.png' title='travel'/>
+		<img class='text inactive' src='../media/interface/travel_txt.png' title='Travel'/>
+		<img class='text active' src='../media/interface/travel_txt_underline.png' title='Travel'/>
 	</a>
 </nav>


### PR DESCRIPTION
This PR makes some changes to `src/inc/meta.nav.htm`, `src/inc/home.htm`, and `links/main.css` with the objectives of:

1. Keep the page elements from shifting as the nav images are loaded.
2. Make the nav images wrap more freely to make them less cramped on narrow viewports.
3. Allow the navigation to be used by screen readers or if the images fail to load.

This is accomplished with the following general changes:

1. Specifying [`width`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#width) and [`height`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#height) attributes on `<img>` tags to tell the page compositor how large the the PNGs will be before they are loaded. If the CSS rule `width: 100%` is used, `height: auto` must be included to preserve the image aspect ratio.
2. Removing the `max-width: XX%` CSS rules on the nav elements allow them to wrap more freely, down to a single link per row on the narrowest.
3. Using the [`alt`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#alt) attribute instead of [`title`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/title) when labeling images. 

   Using the `aria-label` attribute on the `nav > a` elements so that a screen reader will immediately read the name of the link rather than a description of the icon art. 

   Also for images which have `filter: invert(1)` applied in dark mode, their alt text color was set to black in order for it to be inverted to white, otherwise the alt text would appear black on black if the image failed to load.

One improvement that would require more involved changes is to use the [`aria-current`](https://w3c.github.io/aria/#aria-current) attribute on the nav link which indicates the current page, as a way of telling accessibility devices which page they are on. This would require dynamically altering the HTML of the nav at build time.