### PR TITLE
Add `<meta name='color-scheme'>`

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -183,6 +183,7 @@ build(FILE *f, Lexicon *l, char *name, char *srcpath)
 		"<meta charset='utf-8'>"
 		"<meta name='thumbnail' content='" DOMAIN "media/services/rss.jpg' />"
 		"<meta name='viewport' content='width=device-width,initial-scale=1'>"
+		"<meta name='color-scheme' content='light dark'>"
 		"<link rel='alternate' type='application/rss+xml' title='RSS Feed' "
 		"href='../links/rss.xml' />"
 		"<link rel='stylesheet' type='text/css' href='../links/main.css'>"


### PR DESCRIPTION
The [`color-scheme` meta tag][0] provides a signal to the browser about what color schemes the website supports it. Without it, browsers default to light mode, which means that viewing the page before any CSS has loaded will produce a white background even if the device is in dark mode.

The `color-scheme` meta tag activates the browser's awareness of the OS's color preferences, thus it will choose a dark background for unstyled content, preventing the flash of white.

[0]: https://html.spec.whatwg.org/multipage/semantics.html#meta-color-scheme