### PR TITLE
More image dimensions and alt text

### DIFF
--- a/links/main.css
+++ b/links/main.css
@@ -3,6 +3,8 @@
 
 body { background:#fff; color:#000; overflow-x: hidden; font-family: sans-serif; padding:0; margin:0; }
 
+body nav { display: flex; flex-wrap: wrap; justify-content: center; }
+body nav .nav_link { text-align: center;}
 body nav a img.active { display:none }
 body nav a img.inactive { display:block }
 
@@ -137,7 +139,7 @@ ul.nobull li {list-style-type: none}
 /* Mobile */
 
 @media only screen and (max-width: 1100px) {
-	nav {padding: 20px;text-align: center}
+	nav {padding: 20px;}
 	main {padding: 20px;}
 	.gridprojects, .projects {grid-column-start: span 2;}
 	.article, .grid, .featured {grid-column-start: span 3;}

--- a/links/main.css
+++ b/links/main.css
@@ -57,6 +57,9 @@ main img.medium { max-width: 300px; padding: 10px}
 main img.normal { max-width: 200px;}
 main img.sm { max-width: 88px}
 
+main .ethics-icons { display: flex; gap: 10px }
+main .ethics-icon { width: 100px; height: auto; align-self: end;}
+
 main cite {font-size: 17px;display: block;clear: both;margin-bottom: 30px;}
 main cite:before {content: "— ";}
 main > q { font-size: 20px;font-style: italic;max-width: 500px; display: block; margin-left:30px; }

--- a/links/main.css
+++ b/links/main.css
@@ -119,14 +119,13 @@ ul.nobull li {list-style-type: none}
 
 @media (prefers-color-scheme: dark) {
 	body {background: #000; color: white}
-	nav a img.text, img.invert, footer a.logo { color:#000; filter: invert(1)}
+	nav a img.text, img.invert, footer a.logo, .mono { color:#000; filter: invert(1)}
 	body a { color: white;}
 	main > pre { background: white; color:#000}
 	main > code { background:white; color:#000}
 	body select { color: black; background-color: white;}
 	main .project { border-left:2px solid white }
 	.notice { border-color:white; }
-	.mono { filter: invert(1) }
 	main .progress > div { background-color: white}
 	main .progress > div > span { color: black}
 	footer { border-top: 2px solid white }

--- a/links/main.css
+++ b/links/main.css
@@ -99,7 +99,7 @@ main > table tr > * { padding:5px 15px; vertical-align: top;}
 
 footer { line-height: 45px; clear:both; padding:45px; border-top:2px solid black }
 footer a.logo { margin-right: 20px; float:left }
-footer a.logo img { height: 45px }
+footer a.logo img { width: 45px; height: auto; }
 footer hr { margin-bottom: 15px; display:none;  }
 
 /* Modular */

--- a/links/main.css
+++ b/links/main.css
@@ -25,7 +25,7 @@ nav a img { width:144px; height:auto; display:block; }
 nav .hidden {position:absolute; overflow:hidden; left: -9999px}
 
 main { padding: 0px 0px 45px 45px; max-width:900px; }
-main img { width:100%; height:auto; max-width: 900px; margin-bottom: 15px;}
+main img { display:block; width:100%; height:auto; max-width: 900px; margin-bottom: 15px;}
 main > * { max-width: 900px; margin-bottom: 30px }
 main > h1 { font-size:45px; text-transform: capitalize; display: none}
 main > h2 { font-size:30px; text-transform: capitalize}

--- a/src/inc/2024.htm
+++ b/src/inc/2024.htm
@@ -27,7 +27,7 @@
 
 <h2 id='oct2024'>October 2024</h2>
 
-<img src="../media/content/videos/october_2024.jpg" alt="little ninj has carved a pumpkin, saying BEE-HOLD! The pumpkin is smiling, in a non-threatening and eager kind of way. A bowl with pumpkin pulp and a knife are laying nearby with some fallen tree leaves scattered on the ground." loading="lazy">
+<img src="../media/content/videos/october_2024.jpg" alt="little ninj has carved a pumpkin, saying BEE-HOLD! The pumpkin is smiling, in a non-threatening and eager kind of way. A bowl with pumpkin pulp and a knife are laying nearby with some fallen tree leaves scattered on the ground." loading="lazy" width="1200" height="679">
 
 <ul>
 	<li><b>100r.co</b>, added {rabbit waves} and {logbooks}. Updated <a href='../site/woodstove_installation.html#oct2024'>woodstove installation</a>, {no windlass} with <a href="../media/content/knowledge/anchoring_gloves_old.jpg" target="_blank">1 photo</a>, <a href="../site/mini_dodger.html#october2023">mini dodger</a> and {victoria to sitka logbook} with Week <a href="../site/victoria_to_sitka_logbook.html#week3">3</a> and <a href="../site/victoria_to_sitka_logbook.html#week4">4</a>.</li>
@@ -45,7 +45,7 @@
 
 <h2 id='sep2024'>September 2024</h2>
 
-<img src="../media/content/videos/september_2024.jpg" alt="rek, dev and little ninj sitting around a small fire" loading="lazy">
+<img src="../media/content/videos/september_2024.jpg" alt="rek, dev and little ninj sitting around a small fire" loading="lazy" width="1200" height="679">
 
 <ul>
 	<li><b>100r.co</b>, added a new page: {Victoria to Sitka logbook}.</li>
@@ -66,7 +66,7 @@
 
 <h2 id='aug2024'>August 2024</h2>
 
-<img src="../media/content/videos/august_2024.jpg" alt="rek with a dead laptop battery looking at a grey sky" loading="lazy">
+<img src="../media/content/videos/august_2024.jpg" alt="rek with a dead laptop battery looking at a grey sky" loading="lazy" width="1200" height="679">
 
 <ul>
 	<li><b>100r.co</b>, added new pages: {Sointula}, {Johnstone strait anchorages}, and {Central coast anchorages}. Updated existing pages: added {Yuculta and Dent rapids} with <a href="../site/yuculta_and_dent_rapids.html#southbound">southbound tactics</a>, {no windlass} with 3 new photos, {lpg} with <a href="../site/lpg.html#troubleshoot">troubleshooting</a>, and {gimballed stove} with <a href="../site/gimballed_stove.html#performance">performance tests</a>.</li>
@@ -87,7 +87,7 @@
 
 <h2 id='jul2024'>July 2024</h2>
 
-<img src="../media/content/videos/july_2024.jpg" alt="pidgeon guillemots, a murrelet and floating bull kelp" loading="lazy">
+<img src="../media/content/videos/july_2024.jpg" alt="pidgeon guillemots, a murrelet and floating bull kelp" loading="lazy" width="1200" height="679">
 <ul>
 	<li><b>100r.co</b>, added {Sitka}, and completed route in {us se alaska}.</li>
 	<li><b>{Left}</b>, can now paste binary directly from programs like {Nasu}.</li>
@@ -108,7 +108,7 @@
 
 <h2 id='jun2024'>June 2024</h2>
 
-<img src="../media/content/videos/june_2024.jpg" alt="ninj staring at the alaska flag, which is a constellation" loading="lazy">
+<img src="../media/content/videos/june_2024.jpg" alt="ninj staring at the alaska flag, which is a constellation" loading="lazy" width="1200" height="679">
 <ul>
 	<li><b>100r.co</b>, added {Ketchikan}, {Snug Cove}, {Ratz Harbor}, {Frosty Bay}, {Berg Bay}, {Wrangell}, {Petersburg} and {Ruth Island Cove}. Updated {library}.</li>
 	<li><b><a href="https://wiki.xxiivv.com/site/oekaki.html" target="_blank">Oekaki</a></b>, optimized and added a selection tool.</li>
@@ -126,7 +126,7 @@
 
 <h2 id='may2024'>May 2024</h2>
 
-<img src="../media/content/videos/may_2024.jpg" alt="a rain bird, the mascot of ketchikan" loading="lazy">
+<img src="../media/content/videos/may_2024.jpg" alt="a rain bird, the mascot of ketchikan" loading="lazy" width="1200" height="679">
 
 <ul>
 	<li><b>100r.co</b>, added {Frances Bay}, {Yuculta and Dent Rapids}, {Shoal Bay}, {Port Neville}, {Telegraph Cove}, {Port McNeill}, {Fury Cove}, {Prince Rupert}, {bc north coast anchorages}, {us se alaska} and {united states}.</li>
@@ -147,7 +147,7 @@
 
 <h2 id='apr2024'>April 2024</h2>
 
-<img src="../media/content/videos/april_2024.jpg" alt="Ninj, a little grey ninja, is standing at the top of a sailboat mast while saying: top of pino island" loading="lazy">
+<img src="../media/content/videos/april_2024.jpg" alt="Ninj, a little grey ninja, is standing at the top of a sailboat mast while saying: top of pino island" loading="lazy" width="1200" height="679">
 
 <ul>
 	<li><b>100r.co</b>, added {twilight}, updated our notes on <a href="../site/chainplates.html#april2024">chainplates</a>, <a href="../site/wheel_to_tiller_conversion.html#apr2024">wheel to tiller conversion</a>, <a href="../site/dc_electrical_refit.html#apr2024">cabin lights</a> <a href="../site/standing_rigging_replacement.html#apr2024">standing rigging replacement</a>, {princess louisa inlet}(added maps), {goji no chaimu}(added maps), and {sailing in japan}(fixed some dead links).</li>
@@ -164,7 +164,7 @@
 
 <h2 id='mar2024'>March 2024</h2>
 
-<img src="../media/content/videos/march_2024.jpg" alt="Ninj, a little grey ninja, is stamping down on a just-made rope mat to flatten it out" loading="lazy">
+<img src="../media/content/videos/march_2024.jpg" alt="Ninj, a little grey ninja, is stamping down on a just-made rope mat to flatten it out" loading="lazy" width="1200" height="679">
 
 <ul>
 	<li><b>100r.co</b>, added {chainplates}, {knots}, {washing dishes}, {receiving mail}, updated our notes on {diy carbonation system}, and {refrigeration}.</li>

--- a/src/inc/about.htm
+++ b/src/inc/about.htm
@@ -7,7 +7,7 @@
 </ul>
 -->
 
-<img src='../media/content/about/rabbits2.png' title='the rabbits' alt='A dithered photo of two people with rabbit heads standing near a river' loading='lazy' />
+<img src='../media/content/about/rabbits2.png' title='the rabbits' alt='A dithered photo of two people with rabbit heads standing near a river' loading='lazy' width='1200' height='807'/>
 
 <p><b>Hundred Rabbits</b> is an artist collective that documents low-tech solutions with the hope of building a more resilient future. We live and work aboard a 10 m sailboat named {Pino} in remote parts of the world to learn more about how technology degrades beyond the shores of the western world.</p>
 

--- a/src/inc/meta.footer.htm
+++ b/src/inc/meta.footer.htm
@@ -1,15 +1,15 @@
 <footer>
 	<a class='logo' href="home.html">
-		<img src="../media/interface/logo.svg" aria-label='open homepage' alt="hundred rabbits logo consisting of one hundred white dots">
+		<img src="../media/interface/logo.svg" aria-label='open homepage' alt="hundred rabbits logo consisting of one hundred white dots" width="100" height="100">
 	</a>
 	<span style="float:right">
-		<a href="../site/index.html">All Pages</a> | 
-		<a href="../site/support.html">Support</a> | 
-		<a href="../site/rabbits.html">Contact</a> | 
+		<a href="../site/index.html">All Pages</a> |
+		<a href="../site/support.html">Support</a> |
+		<a href="../site/rabbits.html">Contact</a> |
 		<a href="https://github.com/hundredrabbits/100r.co/blob/main/LICENSE.by-nc-sa-4.0.md" target="_blank">BY-NC-SA 4.0</a>
 	</span>
 	<span>
-		<b>Hundredrabbits</b> © 2024 
+		<b>Hundredrabbits</b> © 2024
 	</span>
 	<!-- Mastodon -->
 	<a href="https://merveilles.town/@neauoire" rel="me" class="hidden"></a>

--- a/src/inc/meta.nav.htm
+++ b/src/inc/meta.nav.htm
@@ -9,32 +9,32 @@
 	</ul>
 </nav>
 <nav>
-	<a href='home.html' class='home_rabbit' aria-label='Home'>
+	<a href='home.html' class='nav_link home_rabbit' aria-label='Home'>
 		<img src='../media/interface/home.png' alt='a rabbit wearing a funky sweater' width='200' height='200'/>
 		<img class='text inactive' src='../media/interface/home_txt.png' alt='Home' width='200' height='35'/>
 		<img class='text active' src='../media/interface/home_txt_underline.png' alt='Home' width='200' height='35'/>
 	</a>
-	<a href='about.html' class='about_rabbit' aria-label='About'>
+	<a href='about.html' class='nav_link about_rabbit' aria-label='About'>
 		<img src='../media/interface/about.png' alt='a mariner rabbit with a spyglass, coiled in ropes' width='200' height='200'/>
 		<img class='text inactive' src='../media/interface/about_txt.png' alt='About' width='200' height='35'/>
 	<img class='text active' src='../media/interface/about_txt_underline.png' alt='About' width='200' height='35'/>
 	</a>
-	<a href='knowledge.html' class='knowledge_rabbit' aria-label='Knowledge'>
+	<a href='knowledge.html' class='nav_link knowledge_rabbit' aria-label='Knowledge'>
 		<img src='../media/interface/knowledge.png' alt='a rabbit holding some rolled up documents' width='200' height='200'/>
 		<img class='text inactive' src='../media/interface/knowledge_txt.png' alt='Knowledge' width='200' height='35'/>
 		<img class='text active' src='../media/interface/knowledge_txt_underline.png' alt='Knowledge' width='200' height='35'/>
 	</a>
-	<a href='articles.html' class='articles_rabbit' aria-label='Articles'>
+	<a href='articles.html' class='nav_link articles_rabbit' aria-label='Articles'>
 		<img src='../media/interface/articles.png' alt='a rabbit laying on their belly and writing into a book' width='200' height='200'/>
 		<img class='text inactive' src='../media/interface/articles_txt.png' alt='Articles' width='200' height='35'/>
 		<img class='text active' src='../media/interface/articles_txt_underline.png' alt='Articles' width='200' height='35'/>
 	</a>
-	<a href='projects.html' class='projects_rabbit' aria-label='Projects'>
+	<a href='projects.html' class='nav_link projects_rabbit' aria-label='Projects'>
 		<img src='../media/interface/projects.png' alt='a rabbit working on a project, taking measurements while while a hard hat' width='200' height='200'/>
 		<img class='text inactive' src='../media/interface/projects_txt.png' alt='Projects' width='200' height='35'/>
 		<img class='text active' src='../media/interface/projects_txt_underline.png' alt='Projects' width='200' height='35'/>
 	</a>
-	<a href='travel.html' class='travel_rabbit' aria-label='Travel'>
+	<a href='travel.html' class='nav_link travel_rabbit' aria-label='Travel'>
 		<img src='../media/interface/travel.png' alt='a rabbit sitting in a small boat wearing a rain coat' width='200' height='200'/>
 		<img class='text inactive' src='../media/interface/travel_txt.png' alt='Travel' width='200' height='35'/>
 		<img class='text active' src='../media/interface/travel_txt_underline.png' alt='Travel' width='200' height='35'/>

--- a/src/inc/mission.htm
+++ b/src/inc/mission.htm
@@ -1,6 +1,6 @@
 <p>We founded <b>Hundred Rabbits</b> so we could dedicate our time to the creation of small, playful, free, open-source software, while considering the impact of our works on the environment, and optimizing toward living more sustainably. We've adapted our software and projects around the limitations of our vessel instead of increasing its limits. We learned to appreciate these limits and think that they make our work better.</p>
 
-<img src='../media/content/knowledge/humanscale.jpg' style='max-width: 350px; float:left; margin: 20px;' loading='lazy'>
+<img src='../media/content/knowledge/humanscale.jpg' style='max-width: 350px; float:left; margin: 20px;' loading='lazy' alt='' width='350' height='251'>
 
 <p>The benefits of many modern technologies today are illusory, and undermine people's self-sufficiency, freedom, and dignity. Ivan Illich proposed the concept of "convivial tools" that honor human agency and creativity. Convivial tools are not proprietary, in the style of many software today, but open-ended, flexible instruments that serve the needs and interests of ordinary individuals and communities.</p>
 

--- a/src/inc/philosophy.htm
+++ b/src/inc/philosophy.htm
@@ -1,4 +1,4 @@
-<img src='../media/content/about/philosophy.jpg' loading='lazy' />
+<img src='../media/content/about/philosophy.jpg' loading='lazy' alt="A black origami rabbit standing among rough stones." width='1086' height='679'/>
 <p>We build software following these rules:</p>
 
 <h3 id='offline_first'>offline first</h3>
@@ -16,6 +16,10 @@
 
 <p>We are aggressively opposed to racism, sexism, homophobia, transphobia, speciesism, nationalism, ethnocentrism, religious fundamentalism, and oppressive and coercive power structures of all kinds. <a href='https://blood-and-dust.com/politics/' target='_blank'>~</a></p>
 
-<a href="https://wiki.xxiivv.com/site/ethics.html" target="_blank"><img src='../media/interface/nonazi.png' style='width:100px' alt='an icon featuring a person throwing the nazi swastika into the trash, where it belongs' arial-label="link to page about ethics"  class='mono'/></a>
-<a href="https://wiki.xxiivv.com/site/ethics.html" target="_blank"><img src='../media/interface/noai.png' alt='the letters AI in a circle overlaid with three arrows' arial-label="link to page about ethics"  style='width:100px' class='mono'/></a>
-<a href="https://wiki.xxiivv.com/site/ethics.html" target="_blank"><img src='../media/interface/crueltyfree.png' alt='a rabbit in a triangle' arial-label="link to page about ethics"  style='width:100px' class='mono'/></a>
+<p>Learn more on <a href="https://wiki.xxiivv.com/site/ethics.html" target="_blank">Devine's Ethics page</a>.</p>
+
+<div class="ethics-icons">
+    <img src='../media/interface/nonazi.png' alt='an icon featuring a person throwing the nazi swastika into the trash, where it belongs' class='mono ethics-icon' width="101" height="100"/>
+    <img src='../media/interface/noai.png' alt='the letters AI in a circle overlaid with three arrows' style='width:100px' class='mono ethics-icon' width="328" height="329"/>
+    <img src='../media/interface/crueltyfree.png' alt='a rabbit in a triangle' style='width:100px' class='mono ethics-icon' width="147" height="117"/>
+</div>

--- a/src/inc/projects.htm
+++ b/src/inc/projects.htm
@@ -11,49 +11,49 @@
 
 <div class='gridprojects'>
     <div class='projects'>
-        <a href="orca.html"><img src="../media/interface/orca.turnip.png" loading="lazy" alt="a turnip-like character with one eye">
+        <a href="orca.html"><img src="../media/interface/orca.turnip.png" loading="lazy" alt="a turnip-like character with one eye" width="512" height="512">
     <h3><a href="orca.html">Orca</a></h3>
         </a>
         <p>A livecoding environment</p>
     </div>
     <div class='projects'>
-        <a href="noodle.html"><img src="../media/interface/noodle.turnip.png" loading="lazy" alt="a bell pepper-shaped character with a diamond-shaped eye">
+        <a href="noodle.html"><img src="../media/interface/noodle.turnip.png" loading="lazy" alt="a bell pepper-shaped character with a diamond-shaped eye" width="512" height="512">
     <h3><a href="noodle.html">Noodle</a></h3>
         </a>
         <p>A sketch tool</p>
     </div>
     <div class='projects'>
-        <a href="left.html"><img src="../media/interface/left.turnip.png" loading="lazy" alt="a root-vegetable shaped character with a long stalk">
+        <a href="left.html"><img src="../media/interface/left.turnip.png" loading="lazy" alt="a root-vegetable shaped character with a long stalk" width="512" height="512">
     <h3><a href="left.html">Left</a></h3>
         </a>
         <p>A writing tool</p>
     </div>
     <div class='projects'>
-        <a href="nasu.html"><img src="../media/interface/nasu.turnip.png" loading="lazy" alt="an eggplant-shaped character with thick leaves">
+        <a href="nasu.html"><img src="../media/interface/nasu.turnip.png" loading="lazy" alt="an eggplant-shaped character with thick leaves" width="512" height="512">
     <h3><a href="nasu.html">Nasu</a></h3>
         </a>
         <p>A spritesheet editor</p>
     </div>
     <div class='projects'>
-        <a href="ronin.html"><img src="../media/interface/ronin.turnip.png" loading="lazy" alt="a ginger-root shaped character with one eye">
+        <a href="ronin.html"><img src="../media/interface/ronin.turnip.png" loading="lazy" alt="a ginger-root shaped character with one eye" width="512" height="512">
     <h3><a href="ronin.html">Ronin</a></h3>
         </a>
         <p>The graphic design tool</p>
     </div>
     <div class='projects'>
-        <a href="dotgrid.html"><img src="../media/interface/dotgrid.turnip.png" loading="lazy" alt="a daikon-shaped character with one eye">
+        <a href="dotgrid.html"><img src="../media/interface/dotgrid.turnip.png" loading="lazy" alt="a daikon-shaped character with one eye" width="512" height="512">
     <h3><a href="dotgrid.html">Dotgrid</a></h3>
         </a>
         <p>The vector tool</p>
     </div>
     <div class='projects'>
-        <a href="adelie.html"><img src="../media/interface/adelie.png" loading="lazy"alt="an adelie penguin">
+        <a href="adelie.html"><img src="../media/interface/adelie.png" loading="lazy" alt="an adelie penguin" width="512" height="512">
     <h3><a href="adelie.html">Adelie</a></h3>
         </a>
         <p>The slideshow tool</p>
     </div>
     <div class='projects'>
-        <a href="uxn.html"><img src="../media/interface/uxn.png" loading="lazy" alt="a goat-like character with horns">
+        <a href="uxn.html"><img src="../media/interface/uxn.png" loading="lazy" alt="a goat-like character with horns" width="512" height="512">
             <h3><a href="uxn.html">Uxn</a></h3>
         </a>
         <p>The virtual machine powering our tools</p>
@@ -64,19 +64,19 @@
 
 <div class='gridprojects'>
     <div class='projects'>
-        <a href="wiktopher.html"><img src="../media/interface/wiktopher_icon.png" loading="lazy" alt="a creature that is a cross between a camel and a fennec">
+        <a href="wiktopher.html"><img src="../media/interface/wiktopher_icon.png" loading="lazy" alt="a creature that is a cross between a camel and a fennec" width="500" height="500">
             <h3><a href="wiktopher.html">Wiktopher</a></h3>
         </a>
         <p>Desert Tales</p>
     </div>
     <div class='projects'>
-        <a href="busy_doing_nothing.html"><img src="../media/interface/bdn.png" loading="lazy" alt="a sailboat sailing on rabbit waves">
+        <a href="busy_doing_nothing.html"><img src="../media/interface/bdn.png" loading="lazy" alt="a sailboat sailing on rabbit waves" width="500" height="500">
             <h3><a href="busy_doing_nothing.html">Busy Doing Nothing</a></h3>
         </a>
         <p>At sea for 51 days, from Japan to Canada</p>
     </div>
     <div class='projects'>
-        <a href="thousand_rooms.html"><img src="../media/interface/tr.png" class="invert" loading="lazy" alt="a small circle within a large circle with a gap at the top, in the gap lies a small dot">
+        <a href="thousand_rooms.html"><img src="../media/interface/tr.png" class="invert" loading="lazy" alt="a small circle within a large circle with a gap at the top, in the gap lies a small dot" width="200" height="198">
             <h3><a href="thousand_rooms.html">Thousand Rooms</a></h3>
         </a>
         <p>A picture e-book following the behaviours of four characters and a room</p>
@@ -87,43 +87,43 @@
 
 <div class='gridprojects'>
     <div class='projects'>
-        <a href="oquonie.html"><img src="../media/interface/oquonie_icon.png" loading="lazy" class="invert" alt="a tall rectangle with a line in the middle">
+        <a href="oquonie.html"><img src="../media/interface/oquonie_icon.png" loading="lazy" class="invert" alt="a tall rectangle with a line in the middle" width="500" height="486">
             <h3><a href="oquonie.html">Oquonie</a></h3>
         </a>
         <p>A textless adventure across an intertwined megastructure</p>
     </div>
     <div class='projects'>
-        <a href="paradise.html"><img src="../media/interface/paradise_icon.png" loading="lazy" class="invert" alt="3 lines running outward starting from the center">
+        <a href="paradise.html"><img src="../media/interface/paradise_icon.png" loading="lazy" class="invert" alt="3 lines running outward starting from the center" width="500" height="486">
             <h3><a href="paradise.html">Paradise</a></h3>
         </a>
         <p>An interactive fiction playground</p>
     </div>
     <div class='projects'>
-        <a href="hiversaires.html"><img src="../media/interface/hiversaires_icon.png" loading="lazy" class="invert" alt="an H with an extra leg">
+        <a href="hiversaires.html"><img src="../media/interface/hiversaires_icon.png" loading="lazy" class="invert" alt="an H with an extra leg" width="500" height="486">
             <h3><a href="hiversaires.html">Hiversaires</a></h3>
         </a>
         <p>A textless point-n-click puzzle game</p>
     </div>
     <div class='projects'>
-        <a href="verreciel.html"><img src="../media/interface/verreciel_icon.png" loading="lazy" class="invert" alt="a T with another horizontal line halfway down its middle">
+        <a href="verreciel.html"><img src="../media/interface/verreciel_icon.png" loading="lazy" class="invert" alt="a T with another horizontal line halfway down its middle" width="500" height="486">
             <h3><a href="verreciel.html">Verreciel</a></h3>
         </a>
         <p>A glass spaceship simulator</p>
     </div>
     <div class='projects'>
-        <a href="markl.html"><img src="../media/interface/markl_icon.png" loading="lazy" class="invert">
+        <a href="markl.html"><img src="../media/interface/markl_icon.png" loading="lazy" class="invert" alt="" width="500" height="486">
             <h3><a href="markl.html">Markl</a></h3>
         </a>
         <p>In production</p>
     </div>
     <div class='projects'>
-        <a href="donsol.html"><img src="../media/interface/donsol.turnip.png" loading="lazy">
+        <a href="donsol.html"><img src="../media/interface/donsol.turnip.png" loading="lazy" alt="" width="500" height="500">
             <h3><a href="donsol.html">Donsol</a></h3>
         </a>
         <p>A solitary card game</p>
     </div>
     <div class='projects'>
-        <a href="niju.html"><img src="../media/interface/niju.turnip.png" loading="lazy">
+        <a href="niju.html"><img src="../media/interface/niju.turnip.png" loading="lazy" alt="" width="500" height="500">
             <h3><a href="niju.html">Niju</a></h3>
         </a>
         <p>A kana learning game</p>
@@ -136,13 +136,13 @@
 
 <div class='gridprojects'>
     <div class='projects'>
-        <a href="videos.html"><img src="../media/interface/videos_icon.png" loading="lazy">
+        <a href="videos.html"><img src="../media/interface/videos_icon.png" loading="lazy" alt="" width="512" height="512">
             <h3><a href="videos.html">Videos</a></h3>
         </a>
         <p>Sailing vlogs films between 2016-2020</p>
     </div>
     <div class='projects'>
-        <a href="rabbit_waves.html"><img src="../media/interface/rabbitwaves_icon.png" loading="lazy">
+        <a href="rabbit_waves.html"><img src="../media/interface/rabbitwaves_icon.png" loading="lazy" alt="" width="512" height="512">
             <h3><a href="rabbit_waves.html">Rabbit Waves</a></h3>
         </a>
         <p>Illustrated communicating and seafaring knowledge</p>

--- a/src/inc/support.htm
+++ b/src/inc/support.htm
@@ -1,4 +1,4 @@
-<img src='../media/content/about/donations.png' alt='an isometric drawing of the interior of a sailboat. Rek, Little Ninj and Devine are sitting in various spots in the boat with their laptops, doing some work.' loading='lazy'>
+<img src='../media/content/about/donations.png' alt='an isometric drawing of the interior of a sailboat. Rek, Little Ninj and Devine are sitting in various spots in the boat with their laptops, doing some work.' loading='lazy' width='900' height='483'>
 
 <p>We don't run advertisements, this website has no tracking or analytics, our studio and its projects are supported by you. We accept donations through <a href="https://buy.stripe.com/eVa2br27kdpB17adQT">Stripe</a>, <a href="https://paypal.me/hundredrabbits">Paypal</a>, <a href='https://liberapay.com/hundredrabbits/donate'>LiberaPay</a>, and <a href="https://patreon.com/hundredrabbits" target="_blank">Patreon</a>. To support us, you can also:</p>
 

--- a/src/inc/website.htm
+++ b/src/inc/website.htm
@@ -1,9 +1,9 @@
-<p><b>Wiki</b>. In April 2021, this website was converted into a wiki. This type of website is a kind of archive and mirror of everything that we have done, and that we have learnt. It's a living document that outlines where we've been, and a tool that advises where we could go.<img src='../media/content/about/wiki.jpg' style='max-width: 300px; float:right; margin: 20px'loading='lazy'/>We append to the documentation of our projects regularly. You can download a copy of the entire website content and sources as a <a href='https://github.com/hundredrabbits/100r.co/archive/refs/heads/main.zip' target='_blank'>.zip</a>.</p>
+<p><b>Wiki</b>. In April 2021, this website was converted into a wiki. This type of website is a kind of archive and mirror of everything that we have done, and that we have learnt. It's a living document that outlines where we've been, and a tool that advises where we could go.
+<img src='../media/content/about/wiki.jpg' style='max-width: 300px; float:right; margin: 20px' loading='lazy' alt='' width='300' height='311'/>
+We append to the documentation of our projects regularly. You can download a copy of the entire website content and sources as a <a href='https://github.com/hundredrabbits/100r.co/archive/refs/heads/main.zip' target='_blank'>.zip</a>.</p>
 
 <p>In all that is shared on the many pages populating this wiki, we reserve the right to be wrong, and to change our minds. We are always learning, and deepening our view and understanding of any one thing.</p>
 
 <p>This wiki is statically generated from a small C89 program, the sources are available <a href='https://github.com/hundredrabbits/100r.co/' target='_blank'>here</a>, if you find a typo, a broken link or have a code specific question, feel free to open an <a href='https://github.com/hundredrabbits/100r.co/issues/new' target='_blank'>issue</a>.</p>
 
 <p>This website has <b>no</b> tracking or analytics.</p>
-
-


### PR DESCRIPTION
This PR adds `width` and `height` attributes to many images that were missing them, to fix reflows during page load.

It also adds some `alt` attributes, most empty because I couldn't come up with a good description. Including `alt` even on undescribed images prevents screen readers from just announcing the URL of the image, which is rarely helpful.

The icons on the bottom of the Philosophy page have been refactored to no longer be links in order to expose their alt text to the accessibility DOM. The link has been moved to a `<p>` tag above them with helpful link text.