### PR TITLE
orca: Improve community links

### DIFF
--- a/src/inc/orca.htm
+++ b/src/inc/orca.htm
@@ -319,10 +319,10 @@ CM1.    Will output lowercase C.
 <p>If you have questions about Orca, or projects to share, come and chat!</p>
 
 <ul>
-    <li><a href="https://llllllll.co/t/orca-livecoding-tool/17689" target="https">Forum</a></li>
-    <li><a href="https://discord.gg/F7W98pXKd7" target="https">Chatroom</a>(Discord)</li>
+    <li><a href="https://llllllll.co/t/orca-livecoding-tool/17689" target="_blank">Forum</a></li>
+    <li><a href="https://discord.gg/F7W98pXKd7" target="_blank">Discord server</a></li>
     <li><a href="https://lists.sr.ht/~rabbits/orca" target="_blank">Mailing list</a></li>
-    <li>Irc channel: <b>#orca</b> on libera</li>
+    <li>IRC channel: <a href="ircs://irc.libera.chat/#orca"><b>#orca</b> on Libera.Chat</a> (<a href="https://web.libera.chat/#orca">web.libra.chat</a>)</li>
 </ul>
 
 {/license}


### PR DESCRIPTION
- Change `target="https"` ([not a valid target according to the standard][0]) to `target="_blank"`, which has the same effect.
- Make Discord link text more descriptive.
- Use an [`ircs://` link][1] for the IRC channel so it becomes clickable, and add another link to Libera's hosted web client.

[0]: https://html.spec.whatwg.org/multipage/document-sequences.html#valid-navigable-target-name-or-keyword
[1]: https://halloy.squidowl.org/url-schemes.html